### PR TITLE
pow operation added with right associativity

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ mod tokens;
 lalrpop_mod!(pub parser);
 
 fn main() {
-    let input = "5 * 3 + (2 - 1) / 4 ; 4 * 4 + 2";
+    let input = "4*2/5+(1^2^3^4)-34";
     
     let expr = parser::ExprsListParser::new()
             .parse(input)

--- a/src/parser.lalrpop
+++ b/src/parser.lalrpop
@@ -38,10 +38,19 @@ FactorOp: OperatorToken = {
     "%" => OperatorToken::MOD,
 };
 
+PowOp: OperatorToken = {
+    "^" => OperatorToken::POW,
+};
+
 
 Term: Box<Expr> = {
+    Primary PowOp Term => Box::new(Expr::BinaryOp(<>)),
+    Primary,
+};
+
+Primary: Box<Expr> = {
     Num => Box::new(Expr::Number(<>)),
-    LParen <Expr> RParen
+    LParen <Expr> RParen,
 };
 
 PrintExpr: Box<Expr> = {
@@ -67,7 +76,6 @@ LBrace: DelimiterToken = {
 Let: KeywordToken = {
     "let" => KeywordToken::LET
 }
-
 
 Else: KeywordToken = {
     "else" => KeywordToken::ELSE

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -1,4 +1,3 @@
-
 #[derive(Debug, PartialEq)]
 pub enum KeywordToken {
     PRINT,
@@ -9,6 +8,7 @@ pub enum KeywordToken {
     IN,
     LET,
 }
+
 #[derive(Debug, PartialEq)]
 pub enum OperatorToken {
     MUL,
@@ -16,7 +16,9 @@ pub enum OperatorToken {
     PLUS,
     MINUS,
     MOD,
+    POW,
 }
+
 #[derive(Debug, PartialEq)]
 pub enum DelimiterToken {
     SEMICOLON,
@@ -26,10 +28,12 @@ pub enum DelimiterToken {
     LBRACE,
     RBRACE,
 }
+
 #[derive(Debug, PartialEq)]
 pub enum IdentifierToken {
     IDENTIFIER(String),
 }
+
 #[derive(Debug, PartialEq)]
 pub enum Token {
     Keyword(KeywordToken),


### PR DESCRIPTION
This pull request introduces support for the power operator (`^`) in the parser, updates the input example in `main.rs`, and performs minor formatting adjustments in `src/tokens.rs`. The most important changes are grouped below by theme:

### Support for Power Operator:

* Added a new `PowOp` rule in `src/parser.lalrpop` to handle the `^` operator, mapping it to `OperatorToken::POW`. Updated the grammar to allow expressions with the power operator.
* Extended the `OperatorToken` enum in `src/tokens.rs` to include the `POW` variant.

### Input Example Update:

* Updated the example input expression in `src/main.rs` to include the power operator (`^`) and other operations for testing.

### Code Formatting Adjustments:

* Added spacing and minor formatting changes in `src/tokens.rs` to improve readability, such as adding blank lines between enum definitions. [[1]](diffhunk://#diff-0d8d38311eebcea9a10be9c17a450fb7f65a52870dd35d6ca4f6412756a61599L1) [[2]](diffhunk://#diff-0d8d38311eebcea9a10be9c17a450fb7f65a52870dd35d6ca4f6412756a61599R31-R36)