### PR TITLE
added parsing for unary, comparison, equality, and semicolons at the end of expressions

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,9 +1,9 @@
-
 use crate::tokens::*;
 
 #[derive(Debug, PartialEq)]
 pub enum Expr {
     Number(i32),
     BinaryOp(Box<Expr>, OperatorToken, Box<Expr>),
-    Print(Box<Expr>)
+    UnaryOp(OperatorToken, Box<Expr>),
+    Print(Box<Expr>),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ mod tokens;
 lalrpop_mod!(pub parser);
 
 fn main() {
-    let input = "4*2/5+(1^2^3^4)-34";
+    let input = "-1 + 5;";
     
     let expr = parser::ExprsListParser::new()
             .parse(input)

--- a/src/parser.lalrpop
+++ b/src/parser.lalrpop
@@ -1,35 +1,63 @@
 use std::str::FromStr;
 
-
-use crate::ast::{Expr};
+use crate::ast::Expr;
 use crate::tokens::*;
 
 grammar;
 
-
 pub ExprsList: Vec<Box<Expr>> = {
-    <mut v:(<Expr> ";")*> <e:Expr?> => match e {
-        None => v,
-        Some(e) => {
-            v.push(e);
-            v
-        }
+    <v:(<Expr> Semicolon)*> => v
+};
+
+Expr: Box<Expr> = { EqualityExpr };
+
+EqualityExpr: Box<Expr> = {
+    <left:ComparisonExpr> <rest:(EqualityOp ComparisonExpr)*> => {
+        rest.into_iter().fold(left, |l, (op, r)| {
+            Box::new(Expr::BinaryOp(l, op, r))
+        })
     }
 };
 
-Expr: Box<Expr> = {
-    Expr ExprOp Factor => Box::new(Expr::BinaryOp(<>)),
-    Factor,
+EqualityOp: OperatorToken = {
+    "==" => OperatorToken::EQ,
+    "!=" => OperatorToken::NEQ,
 };
 
-ExprOp: OperatorToken = {
+ComparisonExpr: Box<Expr> = {
+    <left:TermExpr> <rest:(ComparisonOp TermExpr)*> => {
+        rest.into_iter().fold(left, |l, (op, r)| {
+            Box::new(Expr::BinaryOp(l, op, r))
+        })
+    }
+};
+
+ComparisonOp: OperatorToken = {
+    ">" => OperatorToken::GT,
+    ">=" => OperatorToken::GTE,
+    "<" => OperatorToken::LT,
+    "<=" => OperatorToken::LTE,
+};
+
+TermExpr: Box<Expr> = {
+    <left:FactorExpr> <rest:(TermOp FactorExpr)*> => {
+        rest.into_iter().fold(left, |l, (op, r)| {
+            Box::new(Expr::BinaryOp(l, op, r))
+        })
+    }
+};
+
+TermOp: OperatorToken = {
     "+" => OperatorToken::PLUS,
     "-" => OperatorToken::MINUS,
 };
 
-Factor: Box<Expr> = {
-    Factor FactorOp Term => Box::new(Expr::BinaryOp(<>)),
-    Term,
+FactorExpr: Box<Expr> = {
+    <left:ExponentExpr> <rest:(FactorOp ExponentExpr)*> => {
+        rest.into_iter().fold(left, |l, (op, r)| {
+            Box::new(Expr::BinaryOp(l, op, r))
+        })
+    }
 };
 
 FactorOp: OperatorToken = {
@@ -38,73 +66,88 @@ FactorOp: OperatorToken = {
     "%" => OperatorToken::MOD,
 };
 
+ExponentExpr: Box<Expr> = {
+    <left:UnaryExpr> <op:PowOp> <right:ExponentExpr> => Box::new(Expr::BinaryOp(left, op, right)),
+    UnaryExpr,
+};
+
 PowOp: OperatorToken = {
     "^" => OperatorToken::POW,
 };
 
-
-Term: Box<Expr> = {
-    Primary PowOp Term => Box::new(Expr::BinaryOp(<>)),
-    Primary,
+UnaryExpr: Box<Expr> = {
+    <op:UnaryOp> <expr:UnaryExpr> => Box::new(Expr::UnaryOp(op, expr)),
+    PrimaryExpr,
 };
 
-Primary: Box<Expr> = {
+UnaryOp: OperatorToken = {
+    "!" => OperatorToken::NOT,
+    "-" => OperatorToken::NEG,
+};
+
+PrimaryExpr: Box<Expr> = {
     Num => Box::new(Expr::Number(<>)),
-    LParen <Expr> RParen,
+    LParen <Expr> RParen => Box::new(*<>),
+    PrintExpr,
 };
 
 PrintExpr: Box<Expr> = {
-    Print LParen <Expr> RParen => Box::new(Expr::Print(<>)), //Current work
+    Print LParen <Expr> RParen => Box::new(Expr::Print(<>)),
+};
+
+Semicolon: DelimiterToken = {
+    ";" => DelimiterToken::SEMICOLON,
 };
 
 RParen: DelimiterToken = {
-    ")" => DelimiterToken::RPAREN
+    ")" => DelimiterToken::RPAREN,
 };
 
 LParen: DelimiterToken = {
-    "(" => DelimiterToken::LPAREN
+    "(" => DelimiterToken::LPAREN,
 };
 
 RBrace: DelimiterToken = {
-    "}" => DelimiterToken::RBRACE
+    "}" => DelimiterToken::RBRACE,
 };
 
 LBrace: DelimiterToken = {
-    "{" => DelimiterToken::LBRACE
+    "{" => DelimiterToken::LBRACE,
 };
 
 Let: KeywordToken = {
-    "let" => KeywordToken::LET
-}
+    "let" => KeywordToken::LET,
+};
 
 Else: KeywordToken = {
-    "else" => KeywordToken::ELSE
-}
+    "else" => KeywordToken::ELSE,
+};
 
 Elif: KeywordToken = {
-    "elif" => KeywordToken::ELIF
-}
+    "elif" => KeywordToken::ELIF,
+};
 
 In: KeywordToken = {
-    "in" => KeywordToken::IN
-}
+    "in" => KeywordToken::IN,
+};
 
 If: KeywordToken = {
-    "if" => KeywordToken::IF
-}
+    "if" => KeywordToken::IF,
+};
 
 While: KeywordToken = {
-    "while" => KeywordToken::WHILE
-}
+    "while" => KeywordToken::WHILE,
+};
 
 Print: KeywordToken = {
-    "print" => KeywordToken::PRINT
+    "print" => KeywordToken::PRINT,
 };
 
 Id: String = {
-    r"[A-Za-z][A-Za-z_0-9]*" => String::from_str(<>).unwrap()
+    r"[A-Za-z][A-Za-z_0-9]*" => String::from_str(<>).unwrap(),
 };
 
 Num: i32 = {
-    r"[0-9]+(\.[0-9]+)?" => i32::from_str(<>).unwrap()
+    r"[0-9]+(\.[0-9]+)?" => i32::from_str(<>).unwrap(),
 };
+

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -17,6 +17,14 @@ pub enum OperatorToken {
     MINUS,
     MOD,
     POW,
+    NEG,
+    NOT,
+    EQ,
+    NEQ,
+    GT,
+    GTE,
+    LT,
+    LTE,
 }
 
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
This pull request introduces significant enhancements to the parser and abstract syntax tree (AST) to support unary operators, comparison, and equality operations. Additionally, it refactors the grammar definitions for better modularity and clarity.

### AST Enhancements:
* Added a new `UnaryOp` variant to the `Expr` enum to support unary operations like negation (`-`) and logical NOT (`!`). (`src/ast.rs`, [src/ast.rsL1-R8](diffhunk://#diff-d25063e2bf3df7eea20ef79ad635d40228382a58b57973dbe9150d4022227bbfL1-R8))

### Parser Improvements:
* Refactored the grammar in `src/parser.lalrpop` to include new non-terminals for equality (`EqualityExpr`), comparison (`ComparisonExpr`), and unary expressions (`UnaryExpr`). These changes enable parsing of equality (`==`, `!=`), comparison (`<`, `<=`, `>`, `>=`), and unary operators (`-`, `!`). (`src/parser.lalrpop`, [[1]](diffhunk://#diff-e54fbaba2e815faa0451f69cf4dede45a89f11e71c5ab14e406aa923c6902de7L3-R60) [[2]](diffhunk://#diff-e54fbaba2e815faa0451f69cf4dede45a89f11e71c5ab14e406aa923c6902de7R69-R153)
* Simplified the `ExprsList` rule to handle semicolon-separated expressions more cleanly. (`src/parser.lalrpop`, [src/parser.lalrpopL3-R60](diffhunk://#diff-e54fbaba2e815faa0451f69cf4dede45a89f11e71c5ab14e406aa923c6902de7L3-R60))

### Token Updates:
* Added new operator tokens (`NEG`, `NOT`, `EQ`, `NEQ`, `GT`, `GTE`, `LT`, `LTE`) to the `OperatorToken` enum to support the newly introduced operations. (`src/tokens.rs`, [src/tokens.rsR20-R27](diffhunk://#diff-0d8d38311eebcea9a10be9c17a450fb7f65a52870dd35d6ca4f6412756a61599R20-R27))

### Test Input Update:
* Updated the test input in `src/main.rs` to include a unary operation example (`-1 + 5;`). (`src/main.rs`, [src/main.rsL8-R8](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL8-R8))…end of each expression