### PR TITLE
identifiers, booleans, strings

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -3,6 +3,9 @@ use crate::tokens::*;
 #[derive(Debug, PartialEq)]
 pub enum Expr {
     Number(i32),
+    Boolean(bool),
+    Str(String),
+    Identifier(String),
     BinaryOp(Box<Expr>, OperatorToken, Box<Expr>),
     UnaryOp(OperatorToken, Box<Expr>),
     Print(Box<Expr>),

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ mod tokens;
 lalrpop_mod!(pub parser);
 
 fn main() {
-    let input = "-1 + 5;";
+    let input = "kosaraju;";
     
     let expr = parser::ExprsListParser::new()
             .parse(input)

--- a/src/parser.lalrpop
+++ b/src/parser.lalrpop
@@ -87,8 +87,12 @@ UnaryOp: OperatorToken = {
 
 PrimaryExpr: Box<Expr> = {
     Num => Box::new(Expr::Number(<>)),
+    Str => Box::new(Expr::Str(<>)),
+    Identifier => Box::new(Expr::Identifier(<>)),
     LParen <Expr> RParen => Box::new(*<>),
     PrintExpr,
+    True => Box::new(Expr::Boolean(true)),
+    False => Box::new(Expr::Boolean(false)),
 };
 
 PrintExpr: Box<Expr> = {
@@ -143,7 +147,15 @@ Print: KeywordToken = {
     "print" => KeywordToken::PRINT,
 };
 
-Id: String = {
+True: KeywordToken = {
+    "true" => KeywordToken::TRUE,
+};
+
+False: KeywordToken = {
+    "false" => KeywordToken::FALSE,
+};
+
+Identifier: String = {
     r"[A-Za-z][A-Za-z_0-9]*" => String::from_str(<>).unwrap(),
 };
 
@@ -151,3 +163,6 @@ Num: i32 = {
     r"[0-9]+(\.[0-9]+)?" => i32::from_str(<>).unwrap(),
 };
 
+Str: String = {
+    r#""([^"\\]|\\.)*""# => String::from_str(&<>[1..<>.len()-1]).unwrap(),
+};

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -7,6 +7,8 @@ pub enum KeywordToken {
     IF,
     IN,
     LET,
+    TRUE,
+    FALSE,
 }
 
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
This pull request introduces several enhancements to the abstract syntax tree (AST) and parser of the project, enabling support for new data types (`Boolean`, `String`, and `Identifier`) and their corresponding tokens. Additionally, it updates the lexer to recognize these new tokens and modifies the main input example to reflect the changes.

### Enhancements to the AST:

* Added support for `Boolean`, `String`, and `Identifier` types in the `Expr` enum in `src/ast.rs`. (`[src/ast.rsR6-R8](diffhunk://#diff-d25063e2bf3df7eea20ef79ad635d40228382a58b57973dbe9150d4022227bbfR6-R8)`)

### Updates to the parser:

* Extended the grammar in `src/parser.lalrpop` to handle `Boolean` literals (`true` and `false`), `String` literals, and `Identifiers`. (`[[1]](diffhunk://#diff-e54fbaba2e815faa0451f69cf4dede45a89f11e71c5ab14e406aa923c6902de7R90-R95)`, `[[2]](diffhunk://#diff-e54fbaba2e815faa0451f69cf4dede45a89f11e71c5ab14e406aa923c6902de7L146-R168)`)

### Lexer improvements:

* Added token definitions for `TRUE`, `FALSE`, and `Str` in `src/parser.lalrpop` to support `Boolean` and `String` literals. (`[src/parser.lalrpopL146-R168](diffhunk://#diff-e54fbaba2e815faa0451f69cf4dede45a89f11e71c5ab14e406aa923c6902de7L146-R168)`)
* Updated the `KeywordToken` enum in `src/tokens.rs` to include `TRUE` and `FALSE`. (`[src/tokens.rsR10-R11](diffhunk://#diff-0d8d38311eebcea9a10be9c17a450fb7f65a52870dd35d6ca4f6412756a61599R10-R11)`)

### Miscellaneous:

* Updated the example input in `src/main.rs` to use the new `Identifier` type (`"kosaraju;"`) instead of the previous arithmetic expression. (`[src/main.rsL8-R8](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL8-R8)`)