### PR TITLE
added visitor

### DIFF
--- a/src/ast_nodes/expression.rs
+++ b/src/ast_nodes/expression.rs
@@ -7,6 +7,8 @@ use super::while_loop::WhileNode;
 use super::block::{BlockNode, ExpressionList};
 use super::let_in::{LetInNode,Assignment};
 use crate::tokens::OperatorToken;
+use crate::visitor::accept::Accept;
+use crate::visitor::visitor_trait::Visitor;
 
 #[derive(Debug, PartialEq)]
 pub enum Expression {
@@ -68,4 +70,22 @@ impl Expression {
         Expression::LetIn(LetInNode::new(assignments, body))
     }
     
+} 
+
+impl Accept for Expression {
+    fn accept<V: Visitor<T>,T>(&self, visitor: &mut V) -> T {
+        match self {
+            Expression::Number(node) => visitor.visit_literal_number(node),
+            Expression::Boolean(node) => visitor.visit_literal_boolean(node),
+            Expression::Str(node) => visitor.visit_literal_string(node),
+            Expression::Identifier(node) => visitor.visit_identifier(node),
+            Expression::FunctionCall(node) => visitor.visit_function_call(node),
+            Expression::WhileLoop(node) => visitor.visit_while_loop(node),
+            Expression::CodeBlock(node) => visitor.visit_code_block(node),
+            Expression::BinaryOp(node) => visitor.visit_binary_op(node),
+            Expression::UnaryOp(node) => visitor.visit_unary_op(node),
+            Expression::IfElse(node) => visitor.visit_if_else(node),
+            Expression::LetIn(node) => visitor.visit_let_in(node),
+        }
+    }
 }

--- a/src/ast_nodes/function_def.rs
+++ b/src/ast_nodes/function_def.rs
@@ -16,17 +16,3 @@ impl FunctionDefNode {
         }
     }
 }
-
-// pub struct FunctionCall {
-//     pub name: String,
-//     pub args: Vec<Expression>,
-// }
-// 
-// impl FunctionCall {
-//     pub fn new(name: String, args: Vec<Expression>) -> Self {
-//         FunctionCall {
-//             name,
-//             args,
-//         }
-//     }
-// }

--- a/src/ast_nodes/program.rs
+++ b/src/ast_nodes/program.rs
@@ -1,5 +1,7 @@
+use crate::visitor::accept::Accept;
 use super::function_def::FunctionDefNode;
 use super::expression::Expression;
+use crate::visitor::visitor_trait::Visitor;
 
 #[derive(Debug, PartialEq)]
 pub struct Program{
@@ -21,3 +23,19 @@ impl Statement {
         Statement::StatementFunctionDef(Box::new(func_def))
     }
 }
+
+impl Accept for Program {
+    fn accept<V: Visitor<T>,T>(&self, visitor: &mut V) -> T {
+        visitor.visit_program(self)
+    }
+}
+
+impl Accept for Statement {
+    fn accept<V: Visitor<T>,T>(&self, visitor: &mut V) -> T {
+        match self {
+            Statement::StatementExpression(expr) => expr.accept(visitor),
+            Statement::StatementFunctionDef(node) => visitor.visit_function_def(node),
+        }
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 
 pub mod ast_nodes;
+pub mod visitor;
 pub mod tokens;
 
 lalrpop_util::lalrpop_mod!(pub parser);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,20 @@
 use lalrpop_util::lalrpop_mod;
 pub mod ast_nodes;
+pub mod visitor;
 mod tokens;
+use crate::visitor::printer_visitor::PrinterVisitor;
+use crate::visitor::accept::Accept;
+
 
 lalrpop_mod!(pub parser);
 
-#[cfg(not(test))]
 fn main() {
-    let input = "function cot(x) => 1 / tan(x);";
-
-    let expr = parser::ProgramParser::new().parse(input).unwrap();
-    println!("{:?}", expr);
+    let input = "let x = 5 in x + x ; while ( 10 > 0 ) { let y = 10 in y + y ; }";    
+    
+    let expr = parser::ProgramParser::new()
+            .parse(input)
+            .unwrap();
+    let mut printer = PrinterVisitor;
+    println!("");
+    println!("{}", expr.accept(&mut printer));
 }

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 #[derive(Debug, PartialEq)]
 pub enum KeywordToken {
     //PRINT,
@@ -31,6 +33,33 @@ pub enum OperatorToken {
     ASSIGN,
     CONCAT,
 }
+
+
+
+impl fmt::Display for OperatorToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            OperatorToken::MUL => "*",
+            OperatorToken::DIV => "/",
+            OperatorToken::PLUS => "+",
+            OperatorToken::MINUS => "-",
+            OperatorToken::MOD => "%",
+            OperatorToken::POW => "^",
+            OperatorToken::NEG => "-",
+            OperatorToken::NOT => "!",
+            OperatorToken::EQ => "==",
+            OperatorToken::NEQ => "!=",
+            OperatorToken::GT => ">",
+            OperatorToken::GTE => ">=",
+            OperatorToken::LT => "<",
+            OperatorToken::LTE => "<=",
+            OperatorToken::ASSIGN => "=",
+            OperatorToken::CONCAT => "@",
+        };
+        write!(f, "{}", s)
+    }
+}
+
 
 #[derive(Debug, PartialEq)]
 pub enum DelimiterToken {

--- a/src/visitor/accept.rs
+++ b/src/visitor/accept.rs
@@ -1,0 +1,5 @@
+use super::visitor_trait::Visitor;
+
+pub trait Accept {
+    fn accept<V: Visitor<T>,T>(&self, visitor: &mut V) -> T;
+}

--- a/src/visitor/mod.rs
+++ b/src/visitor/mod.rs
@@ -1,0 +1,3 @@
+pub mod visitor_trait;
+pub mod accept;
+pub mod printer_visitor;

--- a/src/visitor/printer_visitor.rs
+++ b/src/visitor/printer_visitor.rs
@@ -1,0 +1,83 @@
+use crate::ast_nodes::binary_op::BinaryOpNode;
+use crate::ast_nodes::function_call::FunctionCallNode;
+use crate::ast_nodes::unary_op::UnaryOpNode;
+use crate::ast_nodes::if_else::IfElseNode;
+use crate::ast_nodes::literals::{NumberLiteralNode,BooleanLiteralNode,StringLiteralNode,IdentifierNode};
+use crate::ast_nodes::while_loop::WhileNode;
+use crate::ast_nodes::block::BlockNode;
+use crate::ast_nodes::let_in::LetInNode;
+use crate::ast_nodes::function_def::FunctionDefNode;
+use super::visitor_trait::Visitor;
+use super::accept::Accept;
+
+pub struct PrinterVisitor; 
+//Here we can store data like variables and functions, but we just print things in this case
+//so we don't need to store anything
+
+impl Visitor<String> for PrinterVisitor {
+    fn visit_program(&mut self, node: &crate::ast_nodes::program::Program) -> String {
+        let statements: Vec<String> = node.statements.iter()
+            .map(|statement| format!("{} ;\n", statement.accept(self)))
+            .collect();
+        format!("{}", statements.join("\n")) 
+    }
+    fn visit_function_def(&mut self, node: &FunctionDefNode) -> String {
+        let name = &node.name;
+        let params = node.params.join(", ");
+        let body = node.body.accept(self);
+        format!("def {} ({}) {{ \n{}\n}}" , name, params, body)
+    }
+    fn visit_literal_number(&mut self, node: &NumberLiteralNode) -> String {
+        format!("{}", node.value)
+    }
+    fn visit_literal_boolean(&mut self, node: &BooleanLiteralNode) -> String {
+        format!("{}", node.value)
+    }
+    fn visit_literal_string(&mut self, node: &StringLiteralNode) -> String {
+        format!("\"{}\"", node.value)
+    }
+    fn visit_identifier(&mut self, node: &IdentifierNode) -> String {
+        format!("{}", node.value)
+    }
+    fn visit_function_call(&mut self, node: &FunctionCallNode) -> String {
+        let args: Vec<String> = node.arguments.iter()
+            .map(|arg| arg.accept(self))
+            .collect();
+
+        format!("{}({})", node.function_name, args.join(", "))
+    }
+    fn visit_while_loop(&mut self, node: &WhileNode) -> String {
+        let condition = node.condition.accept(self);
+        let body = node.body.accept(self);
+        format!("while ({}) {{\n{}\n}}", condition, body)
+    }
+    fn visit_code_block(&mut self, node: &BlockNode) -> String {
+        let expressions: Vec<String> = node.expression_list.expressions.iter()
+            .map(|expr| expr.accept(self))
+            .collect();
+        format!("{}", expressions.join("\n"))
+    }
+    fn visit_binary_op(&mut self, node: &BinaryOpNode) -> String {
+        let left = node.left.accept(self);
+        let right = node.right.accept(self);
+        
+        format!("{} {} {}", left, node.operator, right)
+    }
+    fn visit_unary_op(&mut self, node: &UnaryOpNode) -> String {
+        let operand = node.operand.accept(self);
+        format!("{} {}", node.operator, operand)
+    }
+    fn visit_if_else(&mut self, node: &IfElseNode) -> String {
+        let condition = node.condition.accept(self);
+        let then_branch = node.then_expression.accept(self);
+        let else_branch = node.else_expression.accept(self);
+        format!("if ({}) {{\n{}\n}} else {{\n{}\n}}", condition, then_branch, else_branch)
+    }
+    fn visit_let_in(&mut self,node: &LetInNode) -> String {
+        let assignments: Vec<String> = node.assignments.iter()
+            .map(|assignment| format!("{} = {}", assignment.identifier, assignment.expression.accept(self)))
+            .collect();
+        let body = node.body.accept(self);
+        format!("let {} in {}", assignments.join(", "), body)
+    }
+}

--- a/src/visitor/visitor_trait.rs
+++ b/src/visitor/visitor_trait.rs
@@ -1,0 +1,26 @@
+use crate::ast_nodes::binary_op::BinaryOpNode;
+use crate::ast_nodes::function_call::FunctionCallNode;
+use crate::ast_nodes::unary_op::UnaryOpNode;
+use crate::ast_nodes::if_else::IfElseNode;
+use crate::ast_nodes::literals::{NumberLiteralNode,BooleanLiteralNode,StringLiteralNode,IdentifierNode};
+use crate::ast_nodes::while_loop::WhileNode;
+use crate::ast_nodes::block::BlockNode;
+use crate::ast_nodes::let_in::LetInNode;
+use crate::ast_nodes::function_def::FunctionDefNode;
+use crate::ast_nodes::program::Program;
+
+pub trait Visitor<T> {
+    fn visit_program(&mut self, node: &Program) -> T;
+    fn visit_function_def(&mut self, node: &FunctionDefNode) -> T;
+    fn visit_literal_number(&mut self, node: &NumberLiteralNode) -> T;
+    fn visit_literal_boolean(&mut self, node: &BooleanLiteralNode) -> T;
+    fn visit_literal_string(&mut self, node: &StringLiteralNode) -> T;
+    fn visit_identifier(&mut self, node: &IdentifierNode) -> T;
+    fn visit_function_call(&mut self, node: &FunctionCallNode) -> T;
+    fn visit_while_loop(&mut self, node: &WhileNode) -> T;
+    fn visit_code_block(&mut self, node: &BlockNode) -> T;
+    fn visit_binary_op(&mut self, node: &BinaryOpNode) -> T;
+    fn visit_unary_op(&mut self, node: &UnaryOpNode) -> T;
+    fn visit_if_else(&mut self, node: &IfElseNode) -> T;
+    fn visit_let_in(&mut self,node: &LetInNode) -> T;
+}


### PR DESCRIPTION
This pull request introduces a visitor pattern implementation for the abstract syntax tree (AST) in the codebase. It includes the addition of the `Visitor` trait, the `Accept` trait, and a concrete implementation of the visitor pattern (`PrinterVisitor`). Additionally, it enhances the `OperatorToken` enum with a `fmt::Display` implementation and updates the main entry point to demonstrate the visitor pattern in action.

### Visitor Pattern Implementation:

* **`Visitor` Trait**: Introduced a `Visitor` trait with methods for visiting various AST node types, such as `Program`, `FunctionDefNode`, `BinaryOpNode`, and others (`src/visitor/visitor_trait.rs`).
* **`Accept` Trait**: Added an `Accept` trait to AST nodes, enabling them to accept visitors and delegate processing (`src/visitor/accept.rs`).
* **Visitor Implementation**: Created `PrinterVisitor`, a concrete visitor that traverses the AST and generates a formatted string representation of the program (`src/visitor/printer_visitor.rs`).

### AST Node Updates:

* **Expression and Program Nodes**: Implemented the `Accept` trait for `Expression`, `Program`, and `Statement` nodes, enabling them to interact with visitors (`src/ast_nodes/expression.rs`, `src/ast_nodes/program.rs`). [[1]](diffhunk://#diff-3d16cd20f9c16cd9c6d124bcda24d45bdb0d05ed0ea05a90e90b9e105e521962R74-R91) [[2]](diffhunk://#diff-0d44c9a91f72e952cac909bd3baa076358734b22e92e2185bf5c271c8251c98fR26-R41)
* **Removed Dead Code**: Cleaned up unused code related to `FunctionCall` in `FunctionDefNode` (`src/ast_nodes/function_def.rs`).

### Enhancements to Tokens:

* **`OperatorToken` Display**: Added a `fmt::Display` implementation for `OperatorToken`, allowing operators to be converted to their string representations (`src/tokens.rs`).

### Main File Updates:

* **Demonstration of Visitor Pattern**: Updated `main.rs` to include a demonstration of the visitor pattern using the `PrinterVisitor` to print a parsed program (`src/main.rs`).

### Modularization:

* **Visitor Module**: Added a new `visitor` module with submodules for the `Visitor` trait, `Accept` trait, and `PrinterVisitor` implementation (`src/visitor/mod.rs`).