### PR TITLE
added support for destructive assignment, for loop, and, or binary operators

### DIFF
--- a/src/ast_nodes/destructive_assign.rs
+++ b/src/ast_nodes/destructive_assign.rs
@@ -1,0 +1,16 @@
+use super::expression::Expression;
+
+#[derive(Debug, PartialEq)]
+pub struct DestructiveAssignNode {
+    pub identifier: String,
+    pub expression: Box<Expression>,
+}
+
+impl DestructiveAssignNode {
+    pub fn new(identifier: String, expression: Expression) -> Self {
+        Self {
+            identifier,
+            expression: Box::new(expression),
+        }
+    }
+}

--- a/src/ast_nodes/expression.rs
+++ b/src/ast_nodes/expression.rs
@@ -5,7 +5,9 @@ use super::if_else::IfElseNode;
 use super::literals::{NumberLiteralNode,BooleanLiteralNode,StringLiteralNode,IdentifierNode};
 use super::while_loop::WhileNode;
 use super::block::{BlockNode, ExpressionList};
+use super::for_loop::ForNode;
 use super::let_in::{LetInNode,Assignment};
+use super::destructive_assign::DestructiveAssignNode;
 use crate::tokens::OperatorToken;
 use crate::visitor::accept::Accept;
 use crate::visitor::visitor_trait::Visitor;
@@ -18,11 +20,13 @@ pub enum Expression {
     Identifier(IdentifierNode),
     FunctionCall(FunctionCallNode),
     WhileLoop(WhileNode),
+    ForLoop(ForNode),
     CodeBlock(BlockNode),
     BinaryOp(BinaryOpNode),
     UnaryOp(UnaryOpNode),
     IfElse(IfElseNode),
     LetIn(LetInNode),
+    DestructiveAssign(DestructiveAssignNode),
 }
 
 impl Expression {
@@ -50,6 +54,10 @@ impl Expression {
         Expression::WhileLoop(WhileNode::new(condition, body))
     }
 
+    pub fn new_for_loop(variable: String, start: Expression, end: Expression, body: Expression) -> Self {
+        Expression::ForLoop(ForNode::new(variable, start, end, body))
+    }
+
     pub fn new_code_block(expression_list: ExpressionList) -> Self {
         Expression::CodeBlock(BlockNode::new(expression_list))
     }
@@ -69,6 +77,10 @@ impl Expression {
     pub fn new_let_in(assignments: Vec<Assignment>, body: Expression) -> Self {
         Expression::LetIn(LetInNode::new(assignments, body))
     }
+
+    pub fn new_destructive_assign(identifier: String, expr: Expression) -> Self {
+        Expression::DestructiveAssign(DestructiveAssignNode::new(identifier, expr))
+    }
     
 } 
 
@@ -81,11 +93,13 @@ impl Accept for Expression {
             Expression::Identifier(node) => visitor.visit_identifier(node),
             Expression::FunctionCall(node) => visitor.visit_function_call(node),
             Expression::WhileLoop(node) => visitor.visit_while_loop(node),
+            Expression::ForLoop(node) => visitor.visit_for_loop(node),
             Expression::CodeBlock(node) => visitor.visit_code_block(node),
             Expression::BinaryOp(node) => visitor.visit_binary_op(node),
             Expression::UnaryOp(node) => visitor.visit_unary_op(node),
             Expression::IfElse(node) => visitor.visit_if_else(node),
             Expression::LetIn(node) => visitor.visit_let_in(node),
+            Expression::DestructiveAssign(node) => visitor.visit_destructive_assign(node),
         }
     }
 }

--- a/src/ast_nodes/for_loop.rs
+++ b/src/ast_nodes/for_loop.rs
@@ -1,0 +1,20 @@
+use crate::ast_nodes::expression::Expression;
+
+#[derive(Debug, PartialEq)]
+pub struct ForNode {
+    pub variable: String,
+    pub start: Box<Expression>,
+    pub end: Box<Expression>,
+    pub body: Box<Expression>,
+}
+
+impl ForNode {
+    pub fn new(variable: String, start: Expression, end: Expression, body: Expression) -> Self {
+        ForNode {
+            variable,
+            start: Box::new(start),
+            end: Box::new(end),
+            body: Box::new(body),
+        }
+    }
+}

--- a/src/ast_nodes/mod.rs
+++ b/src/ast_nodes/mod.rs
@@ -7,5 +7,7 @@ pub mod if_else;
 pub mod let_in;
 pub mod unary_op;
 pub mod while_loop;
+pub mod for_loop;
 pub mod literals;
 pub mod program;
+pub mod destructive_assign;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,19 +1,16 @@
 use lalrpop_util::lalrpop_mod;
 pub mod ast_nodes;
-pub mod visitor;
 mod tokens;
-use crate::visitor::printer_visitor::PrinterVisitor;
+pub mod visitor;
 use crate::visitor::accept::Accept;
-
+use crate::visitor::printer_visitor::PrinterVisitor;
 
 lalrpop_mod!(pub parser);
 
 fn main() {
-    let input = "let x = 5 in x + x ; while ( 10 > 0 ) { let y = 10 in y + y ; }";    
-    
-    let expr = parser::ProgramParser::new()
-            .parse(input)
-            .unwrap();
+    let input = "let a = 42 in if (a % 2 == 0 & a == 42) print(\"even\") else print(\"odd\");";
+
+    let expr = parser::ProgramParser::new().parse(input).unwrap();
     let mut printer = PrinterVisitor;
     println!("");
     println!("{}", expr.accept(&mut printer));

--- a/src/parser.lalrpop
+++ b/src/parser.lalrpop
@@ -48,7 +48,14 @@ FunctionFullDef: FunctionDefNode = {
 };
 
 Expr: Expression = { 
-    EqualityExpr,
+    DestructiveAssignExpr,
+    LogicalOrExpr
+};
+
+DestructiveAssignExpr: Expression = {
+    <id:Identifier> DestructiveAssignOp <e:Expr> => {
+        Expression::new_destructive_assign(id, e)
+    }
 };
 
 ExprsList: ExpressionList = {
@@ -59,6 +66,16 @@ ExprsList: ExpressionList = {
         }
         ExpressionList::new(vec)
     }
+};
+
+LogicalOrExpr: Expression = {
+    LogicalOrExpr LogicalOrOp LogicalAndExpr => Expression::new_binary_op(<>),
+    LogicalAndExpr
+};
+
+LogicalAndExpr: Expression = {
+    LogicalAndExpr LogicalAndOp EqualityExpr => Expression::new_binary_op(<>),
+    EqualityExpr
 };
 
 EqualityExpr: Expression = {
@@ -140,7 +157,26 @@ LetIn: Expression = {
 };
 
 WhileLoop: Expression = {
-    While LParen <condition:Expr> RParen <body:CodeBlock> => Expression::new_while_loop(condition,body),
+    While LParen <condition:Expr> RParen <body:PrimaryExpr> => Expression::new_while_loop(condition,body),
+};
+
+//Maybe catch these errors in a different place (Like Semantic Analysis)
+ForLoop: Expression = {
+    For LParen <id:Identifier> In <call:PrimaryExpr> RParen <body:PrimaryExpr> => {
+        if let Expression::FunctionCall(func_call) = call {
+            if func_call.function_name == "range" && func_call.arguments.len() == 2 {
+                let mut args = func_call.arguments;
+                let start = args.remove(0);
+                let end = args.remove(0);
+                
+                Expression::new_for_loop(id, start, end, body)
+            } else {
+                panic!("For loop must use `range` with exactly two arguments");
+            }
+        } else {
+            panic!("For loop iterable must be a `range` function call");
+        }
+    }
 };
 
 IfElse: Expression = {
@@ -151,7 +187,8 @@ IfElse: Expression = {
 
 PrimaryExpr: Expression = {
     WhileLoop,
-    <name:Identifier> LParen <args:ArgList> RParen => Expression::new_function_call(name,args),
+    ForLoop,
+    <name:Identifier> LParen <args:ArgList> RParen => Expression::new_function_call(name, args),
     Num => Expression::new_number(<>),
     Str => Expression::new_string(<>),
     Identifier => Expression::new_identifier(<>),
@@ -228,6 +265,18 @@ Assign: OperatorToken = {
     "=" => OperatorToken::ASSIGN,
 };
 
+DestructiveAssignOp: OperatorToken = {
+    ":=" => OperatorToken::DASSIGN
+};
+
+LogicalAndOp: OperatorToken = {
+    "&" => OperatorToken::AND,
+};
+
+LogicalOrOp: OperatorToken = {
+    "|" => OperatorToken::OR,
+};
+
 Semicolon: DelimiterToken = {
     ";" => DelimiterToken::SEMICOLON,
 };
@@ -270,6 +319,10 @@ If: KeywordToken = {
 
 While: KeywordToken = {
     "while" => KeywordToken::WHILE,
+};
+
+For: KeywordToken = {
+    "for" => KeywordToken::FOR,
 };
 
 // Print: KeywordToken = {

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -4,6 +4,7 @@ use std::fmt;
 pub enum KeywordToken {
     //PRINT,
     WHILE,
+    FOR,
     ELIF,
     ELSE,
     IF,
@@ -32,6 +33,9 @@ pub enum OperatorToken {
     LTE,
     ASSIGN,
     CONCAT,
+    DASSIGN,
+    OR,
+    AND,
 }
 
 
@@ -55,6 +59,9 @@ impl fmt::Display for OperatorToken {
             OperatorToken::LTE => "<=",
             OperatorToken::ASSIGN => "=",
             OperatorToken::CONCAT => "@",
+            OperatorToken::DASSIGN => ":=",
+            OperatorToken::AND => "&",
+            OperatorToken::OR => "|",
         };
         write!(f, "{}", s)
     }

--- a/src/visitor/printer_visitor.rs
+++ b/src/visitor/printer_visitor.rs
@@ -4,9 +4,11 @@ use crate::ast_nodes::unary_op::UnaryOpNode;
 use crate::ast_nodes::if_else::IfElseNode;
 use crate::ast_nodes::literals::{NumberLiteralNode,BooleanLiteralNode,StringLiteralNode,IdentifierNode};
 use crate::ast_nodes::while_loop::WhileNode;
+use crate::ast_nodes::for_loop::ForNode;
 use crate::ast_nodes::block::BlockNode;
 use crate::ast_nodes::let_in::LetInNode;
 use crate::ast_nodes::function_def::FunctionDefNode;
+use crate::ast_nodes::destructive_assign::DestructiveAssignNode;
 use super::visitor_trait::Visitor;
 use super::accept::Accept;
 
@@ -25,7 +27,7 @@ impl Visitor<String> for PrinterVisitor {
         let name = &node.name;
         let params = node.params.join(", ");
         let body = node.body.accept(self);
-        format!("def {} ({}) {{ \n{}\n}}" , name, params, body)
+        format!("function {} ({}) {{ \n{}\n}}" , name, params, body)
     }
     fn visit_literal_number(&mut self, node: &NumberLiteralNode) -> String {
         format!("{}", node.value)
@@ -50,6 +52,13 @@ impl Visitor<String> for PrinterVisitor {
         let condition = node.condition.accept(self);
         let body = node.body.accept(self);
         format!("while ({}) {{\n{}\n}}", condition, body)
+    }
+    fn visit_for_loop(&mut self, node: &ForNode) -> String {
+        let variable = &node.variable;
+        let start = node.start.accept(self);
+        let end = node.end.accept(self);
+        let body = node.body.accept(self);
+        format!("for ({} in range({}, {})) {{\n{}\n}}", variable, start, end, body)
     }
     fn visit_code_block(&mut self, node: &BlockNode) -> String {
         let expressions: Vec<String> = node.expression_list.expressions.iter()
@@ -79,5 +88,10 @@ impl Visitor<String> for PrinterVisitor {
             .collect();
         let body = node.body.accept(self);
         format!("let {} in {}", assignments.join(", "), body)
+    }
+    fn visit_destructive_assign(&mut self, node: &DestructiveAssignNode) -> String {
+        let id = &node.identifier;
+        let expr = node.expression.accept(self);
+        format!("{} := {}", id, expr)
     }
 }

--- a/src/visitor/visitor_trait.rs
+++ b/src/visitor/visitor_trait.rs
@@ -1,4 +1,6 @@
 use crate::ast_nodes::binary_op::BinaryOpNode;
+use crate::ast_nodes::destructive_assign::DestructiveAssignNode;
+use crate::ast_nodes::for_loop::ForNode;
 use crate::ast_nodes::function_call::FunctionCallNode;
 use crate::ast_nodes::unary_op::UnaryOpNode;
 use crate::ast_nodes::if_else::IfElseNode;
@@ -18,9 +20,11 @@ pub trait Visitor<T> {
     fn visit_identifier(&mut self, node: &IdentifierNode) -> T;
     fn visit_function_call(&mut self, node: &FunctionCallNode) -> T;
     fn visit_while_loop(&mut self, node: &WhileNode) -> T;
+    fn visit_for_loop(&mut self, node: &ForNode) -> T;
     fn visit_code_block(&mut self, node: &BlockNode) -> T;
     fn visit_binary_op(&mut self, node: &BinaryOpNode) -> T;
     fn visit_unary_op(&mut self, node: &UnaryOpNode) -> T;
     fn visit_if_else(&mut self, node: &IfElseNode) -> T;
     fn visit_let_in(&mut self,node: &LetInNode) -> T;
+    fn visit_destructive_assign(&mut self, node: &DestructiveAssignNode) -> T;
 }


### PR DESCRIPTION
This pull request introduces two major features to the codebase: support for `for` loops and destructive assignment (`:=`). Additionally, logical operators (`&` and `|`) are added, along with updates to the parser and visitor implementations to support these new constructs. Below is a breakdown of the most important changes.

### New Features

#### For Loop Support:
* Added `ForNode` to represent `for` loops in the AST, including a constructor for initialization. (`src/ast_nodes/for_loop.rs`, [src/ast_nodes/for_loop.rsR1-R20](diffhunk://#diff-d0b63e963cb55381f4fb88fd1734fea2b02946144085c322a5ffc9153b646463R1-R20))
* Updated `Expression` enum to include `ForLoop` and added a corresponding constructor method. (`src/ast_nodes/expression.rs`, [[1]](diffhunk://#diff-3d16cd20f9c16cd9c6d124bcda24d45bdb0d05ed0ea05a90e90b9e105e521962R23-R29) [[2]](diffhunk://#diff-3d16cd20f9c16cd9c6d124bcda24d45bdb0d05ed0ea05a90e90b9e105e521962R57-R60)
* Extended the parser to handle `for` loops using the `range` function with validation for correct arguments. (`src/parser.lalrpop`, [src/parser.lalrpopL143-R179](diffhunk://#diff-e54fbaba2e815faa0451f69cf4dede45a89f11e71c5ab14e406aa923c6902de7L143-R179))
* Added visitor support for `ForNode`, including a method to format `for` loops for printing. (`src/visitor/printer_visitor.rs`, [src/visitor/printer_visitor.rsR56-R62](diffhunk://#diff-851053216aaa2219403de9126115861b9755a658b08ebc5d78295919e19ead27R56-R62))

#### Destructive Assignment (`:=`):
* Introduced `DestructiveAssignNode` to represent destructive assignments in the AST. (`src/ast_nodes/destructive_assign.rs`, [src/ast_nodes/destructive_assign.rsR1-R16](diffhunk://#diff-5817ac7bfe07034d56f04caa7b442256a5dcdb0fdad9192a88ac52530378cc6aR1-R16))
* Updated `Expression` enum to include `DestructiveAssign` and added a constructor method. (`src/ast_nodes/expression.rs`, [[1]](diffhunk://#diff-3d16cd20f9c16cd9c6d124bcda24d45bdb0d05ed0ea05a90e90b9e105e521962R23-R29) [[2]](diffhunk://#diff-3d16cd20f9c16cd9c6d124bcda24d45bdb0d05ed0ea05a90e90b9e105e521962R81-R84)
* Extended the parser to handle destructive assignment expressions. (`src/parser.lalrpop`, [src/parser.lalrpopL51-R58](diffhunk://#diff-e54fbaba2e815faa0451f69cf4dede45a89f11e71c5ab14e406aa923c6902de7L51-R58))
* Added visitor support for `DestructiveAssignNode`, including a method to format destructive assignments for printing. (`src/visitor/printer_visitor.rs`, [src/visitor/printer_visitor.rsR92-R96](diffhunk://#diff-851053216aaa2219403de9126115861b9755a658b08ebc5d78295919e19ead27R92-R96))

### Parser Enhancements

* Added logical operators (`&` for AND, `|` for OR) to the parser and token definitions. (`src/parser.lalrpop`, [[1]](diffhunk://#diff-e54fbaba2e815faa0451f69cf4dede45a89f11e71c5ab14e406aa923c6902de7R71-R80) [[2]](diffhunk://#diff-e54fbaba2e815faa0451f69cf4dede45a89f11e71c5ab14e406aa923c6902de7R268-R279); `src/tokens.rs`, [[3]](diffhunk://#diff-0d8d38311eebcea9a10be9c17a450fb7f65a52870dd35d6ca4f6412756a61599R36-R38) [[4]](diffhunk://#diff-0d8d38311eebcea9a10be9c17a450fb7f65a52870dd35d6ca4f6412756a61599R62-R64)
* Updated the `PrimaryExpr` rule to include `ForLoop` and adjusted `WhileLoop` to allow `PrimaryExpr` as the body. (`src/parser.lalrpop`, [src/parser.lalrpopR190](diffhunk://#diff-e54fbaba2e815faa0451f69cf4dede45a89f11e71c5ab14e406aa923c6902de7R190))

### Visitor Updates

* Extended the `Visitor` trait to include methods for visiting `ForNode` and `DestructiveAssignNode`. (`src/visitor/visitor_trait.rs`, [src/visitor/visitor_trait.rsR23-R29](diffhunk://#diff-9b554a80222d4dab84f02f7c168976632e16534c6b84b32c5ede0931bd557cd1R23-R29))
* Updated `PrinterVisitor` to handle the new AST nodes (`ForNode` and `DestructiveAssignNode`) for printing. (`src/visitor/printer_visitor.rs`, [[1]](diffhunk://#diff-851053216aaa2219403de9126115861b9755a658b08ebc5d78295919e19ead27R56-R62) [[2]](diffhunk://#diff-851053216aaa2219403de9126115861b9755a658b08ebc5d78295919e19ead27R92-R96)

These changes collectively enhance the language's capabilities, enabling more expressive control flow and assignment operations while maintaining compatibility with the existing architecture.