### PR TITLE
added already defined variable in let in context

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,13 @@ use crate::visitor::printer_visitor::PrinterVisitor;
 lalrpop_mod!(pub parser);
 
 fn main() {
-    let input = "function hello(name : String) : String { 5 + 5 } ; ";
+    let input = "for ( i  in range(1,10) ) { i + 5 ; } ;
+    let x = 5 , y = 10 in (x + y) ;
+    let x = 9 in (y := 10) ;
+    function SumLet (a: Number , b : Number) : Number {
+        let x = a , y = b in (x + y) ;
+    } ;
+    ";
 
     let expr = parser::ProgramParser::new().parse(input).unwrap();
     let mut printer = PrinterVisitor;

--- a/src/semantic_analyzer/semantic_analyzer.rs
+++ b/src/semantic_analyzer/semantic_analyzer.rs
@@ -250,8 +250,11 @@ impl Visitor<TypeSignature> for SemanticAnalyzer {
         self.enter_scope();
         for assig in node.assignments.iter() {
             let expr_type = assig.expression.accept(self);
-            // Check if already exist de definition of the variable !!!!!!!!!!!!!!!!!!!!!!!!!!
-            self.context.symbols.insert(assig.identifier.clone(), expr_type);
+            if let Some(_) = self.context.symbols.get(&assig.identifier) {
+                self.new_error(SemanticError::RedefinitionOfVariable(assig.identifier.clone()));
+            } else {
+                self.context.symbols.insert(assig.identifier.clone(), expr_type);
+            }
         }
         let return_type = node.body.accept(self);
         self.exit_scope();

--- a/src/semantic_analyzer/semantic_errors.rs
+++ b/src/semantic_analyzer/semantic_errors.rs
@@ -12,7 +12,8 @@ pub enum SemanticError {
     UnknownError(String),
     InvalidArgumentsCount(usize,usize,String),
     InvalidTypeArgument(TypeSignature,TypeSignature,usize,String),
-    InvalidFunctionReturn(TypeSignature,TypeSignature,String)
+    InvalidFunctionReturn(TypeSignature,TypeSignature,String),
+    RedefinitionOfVariable(String)
 }
 
 impl SemanticError {
@@ -54,6 +55,9 @@ impl SemanticError {
             }
             SemanticError::InvalidFunctionReturn(body_type,func_return ,func_name ) => {
                 format!("Error: function {} returns {} but function's body returns {}",func_name,func_return,body_type)
+            }
+            SemanticError::RedefinitionOfVariable(var_name) => {
+                format!("Error: variable {} already defined in this context.", var_name)
             }
         }
     }


### PR DESCRIPTION
This pull request introduces changes to enhance semantic analysis and parsing capabilities in the codebase. The most significant updates include adding support for new syntax constructs in the parser, implementing a semantic error for variable redefinition, and extending error formatting for better diagnostics.

### Parsing Enhancements:
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL12-R18): Updated the `input` string to include new syntax constructs such as `for` loops, `let` expressions with multiple bindings, and function definitions with `let` expressions.

### Semantic Analysis Improvements:
* [`src/semantic_analyzer/semantic_analyzer.rs`](diffhunk://#diff-ccd0aec5b8e3d1a5e92f49aa99f8f577a931fc5afb1965d2c6e54c7affb55919L253-R258): Added a check in the `Visitor<TypeSignature>` implementation to detect and report redefinition of variables within the same scope.
* [`src/semantic_analyzer/semantic_errors.rs`](diffhunk://#diff-7e69ea4b41e98982e232f43f9986f86772fa61633d10caec6f9c107f9d23df21L15-R16): Added a new semantic error type `RedefinitionOfVariable` to handle variable redefinition cases.
* [`src/semantic_analyzer/semantic_errors.rs`](diffhunk://#diff-7e69ea4b41e98982e232f43f9986f86772fa61633d10caec6f9c107f9d23df21R59-R61): Extended the `impl SemanticError` to include a formatted error message for `RedefinitionOfVariable`, improving diagnostic clarity.
[Copilot is generating a summary...]