### PR TITLE
Now functions can be declared anywhere, no matter the order

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,13 @@ lalrpop_mod!(pub parser);
 
 fn main() {
     let input = "
+    function SumPro ( a: Number , b : Number ) : Number {
+        if ( a > b ) {
+            5 ;
+        } else {
+            SumLet( a, b ) ;
+        }
+    } ;
     for ( i in range(1,10) ) {
         if ( i > 5 ) {
             i;
@@ -24,6 +31,8 @@ fn main() {
         !\"hola\" ;
     };
 
+    let x = SumLet( 5, 5) in x ;
+
     function SumLet (a: Number , b : Number) : Object {
         if ( a > b ) {
             5 ;
@@ -32,7 +41,6 @@ fn main() {
         }
     } ;
 
-    let x = SumLet( \"hola\", 5) in x ;
     ";
 
     let expr = parser::ProgramParser::new().parse(input).unwrap();

--- a/src/semantic_analyzer/return_types.rs
+++ b/src/semantic_analyzer/return_types.rs
@@ -4,12 +4,12 @@ use crate::types_tree::tree_node::TypeNode;
 #[derive(Debug, Clone, PartialEq)]
 pub struct FunctionInfo {
     pub name: String,
-    pub arguments_types: Vec<TypeNode>,
+    pub arguments_types: Vec<(String,TypeNode)>,
     pub return_type: TypeNode
 }
 
 impl FunctionInfo {
-    pub fn new(name: String, arguments_types: Vec<TypeNode>, return_type: TypeNode) -> Self {
+    pub fn new(name: String, arguments_types: Vec<(String,TypeNode)>, return_type: TypeNode) -> Self {
         FunctionInfo {
             name,
             arguments_types,

--- a/src/semantic_analyzer/semantic_errors.rs
+++ b/src/semantic_analyzer/semantic_errors.rs
@@ -15,7 +15,8 @@ pub enum SemanticError {
     InvalidTypeArgument(TypeNode,TypeNode,usize,String),
     InvalidFunctionReturn(TypeNode,TypeNode,String),
     RedefinitionOfVariable(String),
-    UndefinedType(String)
+    UndefinedType(String),
+    ParamNameAlreadyExist(String,String)
 }
 
 impl SemanticError {
@@ -63,6 +64,9 @@ impl SemanticError {
             }
             SemanticError::UndefinedType(type_name) => {
                 format!("Error: type {} is not defined.", type_name)
+            }
+            SemanticError::ParamNameAlreadyExist(param_name, func_name) => {
+                format!("Error: parameter name {} already exists in the context of function {}.", param_name, func_name)
             }
         }
     }


### PR DESCRIPTION
This pull request introduces several enhancements to the semantic analyzer and parser, focusing on improving function signature handling, error reporting, and type-checking mechanisms. Key changes include adding support for named function parameters in the `FunctionInfo` structure, implementing a method to extract function names and signatures, refining error handling for parameter name conflicts, and updating type-checking logic to accommodate the new parameter structure.

### Enhancements to Function Signature Handling:
* [`src/semantic_analyzer/return_types.rs`](diffhunk://#diff-ad6acb13e9f6f07080b7af3d50ff80355a089d6fae3a4e1db410251191b4e958L7-R12): Updated the `FunctionInfo` structure to include named function parameters (`Vec<(String, TypeNode)>`) instead of just types, and adjusted the `new` constructor accordingly.
* [`src/semantic_analyzer/semantic_analyzer.rs`](diffhunk://#diff-ccd0aec5b8e3d1a5e92f49aa99f8f577a931fc5afb1965d2c6e54c7affb55919R71-R100): Added a new method, `get_functions_names_and_signatures`, to extract function names and signatures from the AST and populate the semantic context. This method checks for parameter name conflicts and undefined types.

### Improvements to Type-Checking Logic:
* [`src/semantic_analyzer/semantic_analyzer.rs`](diffhunk://#diff-ccd0aec5b8e3d1a5e92f49aa99f8f577a931fc5afb1965d2c6e54c7affb55919L96-L125): Refactored `visit_function_def` to use the `declared_functions` context for retrieving function parameter types, simplifying the logic and ensuring consistency.
* [`src/semantic_analyzer/semantic_analyzer.rs`](diffhunk://#diff-ccd0aec5b8e3d1a5e92f49aa99f8f577a931fc5afb1965d2c6e54c7affb55919L161-R179): Updated argument type-checking in function calls to account for the new `(String, TypeNode)` structure.

### Enhanced Error Reporting:
* [`src/semantic_analyzer/semantic_errors.rs`](diffhunk://#diff-7e69ea4b41e98982e232f43f9986f86772fa61633d10caec6f9c107f9d23df21L18-R19): Added a new error type, `ParamNameAlreadyExist`, to handle cases where parameter names conflict within the same function. Updated the error formatting logic to include this new error type. [[1]](diffhunk://#diff-7e69ea4b41e98982e232f43f9986f86772fa61633d10caec6f9c107f9d23df21L18-R19) [[2]](diffhunk://#diff-7e69ea4b41e98982e232f43f9986f86772fa61633d10caec6f9c107f9d23df21R68-R70)

### Parser Updates:
* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR14-R20): Added new sample functions (`SumPro` and `SumLet`) and removed redundant code in the example input for testing the updated semantic analyzer. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR14-R20) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR34-R35) [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL35)