### PR TITLE
Feat/types semantic analyzer

### DIFF
--- a/src/ast_nodes/binary_op.rs
+++ b/src/ast_nodes/binary_op.rs
@@ -1,7 +1,7 @@
 use super::expression::Expression;
 use crate::{tokens::OperatorToken, types_tree::tree_node::TypeNode};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq,Clone)]
 pub struct BinaryOpNode {
     pub left: Box<Expression>,
     pub operator: OperatorToken,

--- a/src/ast_nodes/block.rs
+++ b/src/ast_nodes/block.rs
@@ -2,7 +2,7 @@ use crate::types_tree::tree_node::TypeNode;
 
 use super::expression::Expression;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq,Clone)]
 pub struct ExpressionList {
     pub expressions: Box<Vec<Expression>>,
 }
@@ -15,7 +15,7 @@ impl ExpressionList {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq,Clone)]
 pub struct BlockNode {
     pub expression_list: Box<ExpressionList>,
     pub node_type: Option<TypeNode>,

--- a/src/ast_nodes/destructive_assign.rs
+++ b/src/ast_nodes/destructive_assign.rs
@@ -2,7 +2,7 @@ use crate::types_tree::tree_node::TypeNode;
 
 use super::expression::Expression;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq,Clone)]
 pub struct DestructiveAssignNode {
     pub identifier: Box<Expression>,
     pub expression: Box<Expression>,

--- a/src/ast_nodes/expression.rs
+++ b/src/ast_nodes/expression.rs
@@ -14,7 +14,7 @@ use crate::visitor::accept::Accept;
 use crate::visitor::visitor_trait::Visitor;
 use crate::ast_nodes::type_instance::TypeInstanceNode;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq,Clone)]
 pub enum Expression {
     Number(NumberLiteralNode),
     Boolean(BooleanLiteralNode),

--- a/src/ast_nodes/for_loop.rs
+++ b/src/ast_nodes/for_loop.rs
@@ -1,6 +1,6 @@
 use crate::{ast_nodes::expression::Expression, types_tree::tree_node::TypeNode};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq,Clone)]
 pub struct ForNode {
     pub variable: String,
     pub start: Box<Expression>,

--- a/src/ast_nodes/function_call.rs
+++ b/src/ast_nodes/function_call.rs
@@ -2,7 +2,7 @@ use crate::types_tree::tree_node::TypeNode;
 
 use super::expression::Expression;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq,Clone)]
 pub struct FunctionCallNode {
     pub function_name: String,             
     pub arguments: Vec<Expression>,

--- a/src/ast_nodes/function_def.rs
+++ b/src/ast_nodes/function_def.rs
@@ -17,7 +17,7 @@ impl FunctionParams {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq,Clone)]
 pub struct FunctionDefNode {
     pub name: String,
     pub params: Vec<FunctionParams>,

--- a/src/ast_nodes/if_else.rs
+++ b/src/ast_nodes/if_else.rs
@@ -3,7 +3,7 @@ use crate::types_tree::tree_node::TypeNode;
 use super::expression::Expression;
 
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq,Clone)]
 pub struct IfElseNode {
     pub condition: Box<Expression>,
     pub then_expression: Box<Expression>,

--- a/src/ast_nodes/let_in.rs
+++ b/src/ast_nodes/let_in.rs
@@ -2,7 +2,7 @@ use crate::types_tree::tree_node::TypeNode;
 
 use super::expression::Expression;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq,Clone)]
 pub struct Assignment { //TODO Add optional Signature Assignment
     pub identifier: String,
     pub expression: Box<Expression>,
@@ -17,7 +17,7 @@ impl Assignment {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq,Clone)]
 pub struct LetInNode {
     pub assignments: Vec<Assignment>,
     pub body: Box<Expression>,

--- a/src/ast_nodes/literals.rs
+++ b/src/ast_nodes/literals.rs
@@ -2,7 +2,7 @@ use core::str;
 
 use crate::types_tree::tree_node::TypeNode;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq,Clone)]
 pub struct NumberLiteralNode {
     pub value: f64,
     pub node_type: Option<TypeNode>,
@@ -19,7 +19,7 @@ impl NumberLiteralNode {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq,Clone)]
 pub struct BooleanLiteralNode {
     pub value: bool,
     pub node_type: Option<TypeNode>,
@@ -36,7 +36,7 @@ impl BooleanLiteralNode {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq,Clone)]
 pub struct StringLiteralNode {
     pub value: String,
     pub node_type: Option<TypeNode>,
@@ -53,7 +53,7 @@ impl StringLiteralNode {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq,Clone)]
 pub struct IdentifierNode {
     pub value: String,
     pub node_type: Option<TypeNode>,

--- a/src/ast_nodes/type_def.rs
+++ b/src/ast_nodes/type_def.rs
@@ -1,4 +1,4 @@
-use crate::ast_nodes::{expression::Expression, function_def::{FunctionDefNode, FunctionParams}, let_in::Assignment};
+use crate::{ast_nodes::{expression::Expression, function_def::{FunctionDefNode, FunctionParams}, let_in::Assignment}, types_tree::tree_node::TypeNode};
 
 pub struct TypeInherits {
     pub identifier: String,
@@ -11,7 +11,7 @@ impl TypeInherits {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq,Clone)]
 pub enum TypeMember {
     Property(Assignment),
     Method(FunctionDefNode),
@@ -27,13 +27,14 @@ impl TypeMember {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct TypeDefNode {
     pub identifier: String,
     pub params: Vec<FunctionParams>,
     pub parent: Option<String>,
     pub parent_args: Vec<Expression>,
     pub members: Vec<TypeMember>,
+    pub node_type: Option<TypeNode>,
 }
 
 impl TypeDefNode {
@@ -44,6 +45,10 @@ impl TypeDefNode {
             parent,
             parent_args,
             members,
+            node_type: None,
         }
+    }
+    pub fn set_type(&mut self, node_type: TypeNode) {
+        self.node_type = Some(node_type);
     }
 }

--- a/src/ast_nodes/type_instance.rs
+++ b/src/ast_nodes/type_instance.rs
@@ -1,13 +1,19 @@
+use crate::types_tree::tree_node::TypeNode;
+
 use super::expression::Expression;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq,Clone)]
 pub struct TypeInstanceNode {
     pub type_name: String,             
     pub arguments: Vec<Expression>,
+    pub node_type: Option<TypeNode>,
 }
 
 impl TypeInstanceNode {
     pub fn new(type_name: String, arguments: Vec<Expression>) -> Self {
-        TypeInstanceNode { type_name, arguments }
+        TypeInstanceNode { type_name, arguments, node_type: None }
+    }
+    pub fn set_type(&mut self, node_type: TypeNode) {
+        self.node_type = Some(node_type);
     }
 }

--- a/src/ast_nodes/type_member_access.rs
+++ b/src/ast_nodes/type_member_access.rs
@@ -1,9 +1,11 @@
-use crate::ast_nodes::{expression::Expression, function_call::FunctionCallNode};
+use crate::{ast_nodes::{expression::Expression, function_call::FunctionCallNode}, types_tree::tree_node::TypeNode};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq,Clone)]
 pub struct TypePropAccessNode {
     pub object: Box<Expression>,
     pub member: Box<String>,
+    pub node_type: Option<TypeNode>
+    
 }
 
 impl TypePropAccessNode {
@@ -11,14 +13,19 @@ impl TypePropAccessNode {
         TypePropAccessNode {
             object: Box::new(object),
             member: Box::new(member),
+            node_type: None,
         }
+    }
+    pub fn set_type(&mut self, node_type: TypeNode) {
+        self.node_type = Some(node_type);
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq,Clone)]
 pub struct TypeFunctionAccessNode {
     pub object: Box<Expression>,
     pub member: Box<FunctionCallNode>,
+    pub node_type: Option<TypeNode>
 }
 
 impl TypeFunctionAccessNode {
@@ -26,6 +33,10 @@ impl TypeFunctionAccessNode {
         TypeFunctionAccessNode {
             object: Box::new(object),
             member: Box::new(member),
+            node_type: None,
         }
+    }
+    pub fn set_type(&mut self, node_type: TypeNode) {
+        self.node_type = Some(node_type);
     }
 }

--- a/src/ast_nodes/unary_op.rs
+++ b/src/ast_nodes/unary_op.rs
@@ -1,7 +1,7 @@
 use crate::{tokens::OperatorToken, types_tree::tree_node::TypeNode};
 use super::expression::Expression;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq,Clone)]
 pub struct UnaryOpNode {
     pub operator: OperatorToken,
     pub operand: Box<Expression>,

--- a/src/ast_nodes/while_loop.rs
+++ b/src/ast_nodes/while_loop.rs
@@ -1,6 +1,6 @@
 use crate::{ast_nodes::expression::Expression, types_tree::tree_node::TypeNode};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq,Clone)]
 pub struct WhileNode {
     pub condition: Box<Expression>,
     pub body: Box<Expression>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,11 +35,12 @@ fn main() {
         name = name;
         lastname = lastname;
 
-        name(): String => self.name @ \" \" @ self.lastname ;
+        name() : String => name @ lastname ;
+        
     } ;
 
     type Knight inherits Person {
-        name() : Number => 5 + base();
+        name() : String => \"Sir\" @ \" \" @ base();
     } ;
 
     let p = new Knight(\"Diego\", \"Viera\") in p.name() ;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,53 +11,38 @@ lalrpop_mod!(pub parser);
 
 fn main() {
     let input = "
-    type Point (x: Number, y: Number) {
+    type Point(x : Number, y : Number) {
         x = x;
         y = y;
 
         getX() : Number => self.x;
         getY() : Number => self.y;
 
-        setX(x: Number) : Number => 5 := x ;
+        setX(x: Number) : Number =>  self.x := x ;
         setY(y: Number) : Number => self.y := y ;
     }; 
 
-    type PolarPoint(phi: Number, rho: Number) inherits Point(rho * sin(phi), rho * cos(phi)) {
-        rho() : Number => sqrt(getX() ^ 2 + getY() ^ 2);
+    let x = new Point(4,5) in ( x.getX() + x.getY() ) ;
+
+    type PolarPoint(rho: Number, phi: Number, lol: Number) inherits Point(rho * phi, rho * phi) {
+        rho() : Number => self.getX() ^ 2 + self.getY() ^ 2;
     };
 
-    let x = new Point(3, 4) in x.getX() + x.getY() + x.prop ;
+    let x = new PolarPoint(4,5,7) in ( x.getX() + x.getY() ) ;
+    let x = new Point(4,5) in ( x.getX() + x.getY() ) ;
 
-    function SumPro ( a: Number , b : Number ) : Number {
-        if ( a > b ) {
-            5 ;
-        } else {
-            SumLet( a, b ) ;
-        }
+    type Person (name : String , lastname: String) {
+        name = name;
+        lastname = lastname;
+
+        name(): String => self.name @ \" \" @ self.lastname ;
     } ;
 
-    for ( i in range(1,10) ) {
-        if ( i > 5 ) {
-            i;
-        } else {
-            \"hola\";
-        }
-    };
-    let x = 5 in ( x + x ) ;
-    let y = 4 , z = 3 in ( x + y + z ) ;
-    while ( !(3 < 4) ) { 
-        !\"hola\" ;
-    };
-
-    let x = SumLet( 5, 5) in x ;
-
-    function SumLet (a: Number , b : Number) : Object {
-        if ( a > b ) {
-            5 ;
-        } else {
-            \"hola\" ;
-        }
+    type Knight inherits Person {
+        name() : Number => 5 + base();
     } ;
+
+    let p = new Knight(\"Diego\", \"Viera\") in p.name() ;
 
     ";
 

--- a/src/semantic_analyzer/return_types.rs
+++ b/src/semantic_analyzer/return_types.rs
@@ -1,15 +1,15 @@
 use std::collections::HashMap;
-use crate::types_tree::tree_node::TypeNode;
+use crate::ast_nodes::type_def::TypeDefNode;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct FunctionInfo {
     pub name: String,
-    pub arguments_types: Vec<(String,TypeNode)>,
-    pub return_type: TypeNode
+    pub arguments_types: Vec<(String,String)>,
+    pub return_type: String,
 }
 
 impl FunctionInfo {
-    pub fn new(name: String, arguments_types: Vec<(String,TypeNode)>, return_type: TypeNode) -> Self {
+    pub fn new(name: String, arguments_types: Vec<(String,String)>, return_type: String) -> Self {
         FunctionInfo {
             name,
             arguments_types,
@@ -20,6 +20,9 @@ impl FunctionInfo {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SemanticContext {
-    pub symbols: HashMap<String, TypeNode>, 
-    pub declared_functions: HashMap<String, FunctionInfo>
+    pub symbols: HashMap<String, String>, // Maps variable names to their types
+    pub declared_functions: HashMap<String, FunctionInfo>,
+    pub declared_types: HashMap<String, TypeDefNode>,
+    pub current_type: Option<String>,
+    pub current_function: Option<String>
 }

--- a/src/semantic_analyzer/semantic_analyzer.rs
+++ b/src/semantic_analyzer/semantic_analyzer.rs
@@ -394,6 +394,7 @@ impl Visitor<TypeNode> for SemanticAnalyzer {
                     self.get_built_in_types(&BuiltInTypes::Unknown)
                 }
             },
+            OperatorToken::NEQ |
             OperatorToken::GT |
             OperatorToken::GTE |
             OperatorToken::LT |

--- a/src/semantic_analyzer/semantic_errors.rs
+++ b/src/semantic_analyzer/semantic_errors.rs
@@ -12,11 +12,17 @@ pub enum SemanticError {
     UndeclaredFunction(String),
     UnknownError(String),
     InvalidArgumentsCount(usize,usize,String),
-    InvalidTypeArgument(TypeNode,TypeNode,usize,String),
+    InvalidTypeArgument(String,String,String,usize,String),
     InvalidFunctionReturn(TypeNode,TypeNode,String),
     RedefinitionOfVariable(String),
     UndefinedType(String),
-    ParamNameAlreadyExist(String,String)
+    ParamNameAlreadyExist(String,String,String),
+    RedefinitionOfType(String),
+    CicleDetected(String),
+    InvalidTypeArgumentCount(usize,usize,String),
+    InvalidTypeFunctionAccess(String,String),
+    InvalidTypePropertyAccess(String,String),
+    InvalidTypeProperty(String, String),
 }
 
 impl SemanticError {
@@ -53,8 +59,8 @@ impl SemanticError {
             SemanticError::InvalidArgumentsCount(curr_arg_count,func_arg_count,func_name) => {
                 format!("Error: function call to {}, expected {} arguments, found {}.",func_name,func_arg_count,curr_arg_count)
             }
-            SemanticError::InvalidTypeArgument(curr_type,func_arg_type,arg_pos ,func_name ) => {
-                format!("Error: function {} receives {} on argument {} but {} was found.",func_name,func_arg_type.type_name,arg_pos + 1,curr_type.type_name)
+            SemanticError::InvalidTypeArgument(stmt,curr_type,arg_type,arg_pos ,stmt_name ) => {
+                format!("Error: {} {} receives {} on argument {} but {} was found.",stmt,stmt_name,arg_type,arg_pos + 1,curr_type)
             }
             SemanticError::InvalidFunctionReturn(body_type,func_return ,func_name ) => {
                 format!("Error: function {} returns {} but function's body returns {}",func_name,func_return.type_name,body_type.type_name)
@@ -65,8 +71,26 @@ impl SemanticError {
             SemanticError::UndefinedType(type_name) => {
                 format!("Error: type {} is not defined.", type_name)
             }
-            SemanticError::ParamNameAlreadyExist(param_name, func_name) => {
-                format!("Error: parameter name {} already exists in the context of function {}.", param_name, func_name)
+            SemanticError::ParamNameAlreadyExist(param_name, stmt_name, stmt) => {
+                format!("Error: parameter name {} already exists in the context of {} {}.", param_name, stmt, stmt_name )
+            }
+            SemanticError::RedefinitionOfType(type_name) => {
+                format!("Error: type {} already defined in this context.", type_name)
+            }
+            SemanticError::CicleDetected(cycle_node) => {
+                format!("Error: Cicle detected on type {}", cycle_node)
+            }
+            SemanticError::InvalidTypeArgumentCount(curr_arg_count, expected_arg_count, type_name) => {
+                format!("Error: type {} expected {} arguments, found {}.", type_name, expected_arg_count, curr_arg_count)
+            }
+            SemanticError::InvalidTypeFunctionAccess(type_name, function_name) => {
+                format!("Error: type {} does not have a function named {}.", type_name, function_name)
+            }
+            SemanticError::InvalidTypePropertyAccess(type_name, property_name) => {
+                format!("Error: can not access property {} of type {} because properties are private.", property_name, type_name)
+            }
+            SemanticError::InvalidTypeProperty(type_name, property_name) => {
+                format!("Error: type {} does not have a property named {}.", type_name, property_name)
             }
         }
     }

--- a/src/types_tree/tree_node.rs
+++ b/src/types_tree/tree_node.rs
@@ -1,38 +1,53 @@
 use std::collections::HashMap;
 
+use crate::ast_nodes::function_def::{FunctionDefNode, FunctionParams};
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct TypeNode {
     pub type_name: String,
     pub depth: i32,
-    pub parent: Option<Box<TypeNode>>,
-    pub children: Vec<Box<TypeNode>>,
-    pub variables: HashMap<String, Box<TypeNode>>, // variables associated with this type
-    pub methods: HashMap<String, Box<TypeNode>>, // methods associated with this type
+    pub params: Vec<FunctionParams>,
+    pub parent: Option<String>,
+    pub children: Vec<String>,
+    pub variables: HashMap<String, Box<String>>, // variables associated with his type name
+    pub methods: HashMap<String, Box<FunctionDefNode>>, // methods associated with his type name
 }
 
 impl TypeNode {
-    pub fn new(type_name: String, depth: i32, parent: Option<Box<TypeNode>>) -> Self {
+    pub fn new(type_name: String, params: Vec<FunctionParams>, depth: i32, parent: Option<String> , children: Vec<String>, variables: HashMap<String, Box<String>>, methods: HashMap<String, Box<FunctionDefNode>>) -> Self {
         TypeNode {
             type_name,
+            params,
             depth,
             parent,
-            children: Vec::new(),
-            variables: HashMap::new(),
-            methods: HashMap::new(),
+            children,
+            variables,
+            methods,
         }
     }
 
-    pub fn add_child(&mut self, mut child: Box<TypeNode>) {
-        child.parent = Some(Box::new(self.clone()));
-        self.children.push(child);
+    pub fn add_child(&mut self, child_name: String) {
+        self.children.push(child_name);
     }
 
-    pub fn add_variable(&mut self, name: String, variable: Box<TypeNode>) {
+    pub fn set_parent(&mut self, parent_name: String) {
+        self.parent = Some(parent_name);
+    }
+
+    pub fn add_variable(&mut self, name: String, variable: Box<String>) {
         self.variables.insert(name, variable);
     }
 
-    pub fn add_method(&mut self, name: String, method: Box<TypeNode>) {
+    pub fn add_method(&mut self, name: String, method: Box<FunctionDefNode>) {
         self.methods.insert(name, method);
+    }
+
+    pub fn get_method(&mut self, method_name: &String) -> Option<Box<FunctionDefNode>> {
+        if let Some(method) = self.methods.get(method_name) {
+            Some(method.clone())
+        } else {
+           None
+        }
     }
 
 }


### PR DESCRIPTION
This pull request introduces several changes to the abstract syntax tree (AST) nodes and semantic analyzer in the codebase. The primary focus is on adding `Clone` trait implementations to various AST node structs and enums, extending type-related functionality, and updating the semantic analyzer to better handle type definitions and type-related context.

### AST Node Enhancements:
* Added the `Clone` trait to all AST node structs and enums, such as `BinaryOpNode`, `BlockNode`, `Expression`, and `TypeDefNode`, enabling easier duplication of these nodes. [[1]](diffhunk://#diff-ec1f420d6cf4c8c298b12e3b8e971a9082ce6bde7c17305c42874c2a01b74d9dL4-R4) [[2]](diffhunk://#diff-b009b0691b5040fa3b99243bd565f0c44e896b368b14d17ecd4f578cde0b622eL5-R5) [[3]](diffhunk://#diff-3d16cd20f9c16cd9c6d124bcda24d45bdb0d05ed0ea05a90e90b9e105e521962L17-R17) [[4]](diffhunk://#diff-4d7fe8d06b5a07f6fd2b3305559fb23fc96b90b2f792af12366193127c5804ceL30-R37) [[5]](diffhunk://#diff-33ef253b8248d68cc12d1bd19f36aa7a112597522fb7e7ebb88b297bc698288bR1-R17) and others)

* Introduced `node_type` fields to several AST nodes (e.g., `TypeInstanceNode`, `TypeDefNode`, `TypePropAccessNode`) to store type information. Corresponding `set_type` methods were added for mutability. [[1]](diffhunk://#diff-4d7fe8d06b5a07f6fd2b3305559fb23fc96b90b2f792af12366193127c5804ceR48-R53) [[2]](diffhunk://#diff-33ef253b8248d68cc12d1bd19f36aa7a112597522fb7e7ebb88b297bc698288bR1-R17) [[3]](diffhunk://#diff-8407fef864175b17524a44a2b7dbc822ec14e43476f7e9e9043a1e4e7d0f8817L1-R40)

### Semantic Analyzer Updates:
* Enhanced the `SemanticContext` struct to include `declared_types`, `current_type`, and `current_function` fields for better tracking of type definitions and the current context during semantic analysis.

* Updated the `SemanticAnalyzer` to process type definitions (`get_types_definitions`) and build types (`build_types`) as part of the analysis pipeline.

### Type System Improvements:
* Modified the `FunctionInfo` struct to use `String` for argument and return types instead of `TypeNode`, simplifying type representation.

* Added `TypeNode` references to several files and updated the `TypeDefNode` struct to include an optional `node_type` field for type inheritance. [[1]](diffhunk://#diff-4d7fe8d06b5a07f6fd2b3305559fb23fc96b90b2f792af12366193127c5804ceL30-R37) [[2]](diffhunk://#diff-4d7fe8d06b5a07f6fd2b3305559fb23fc96b90b2f792af12366193127c5804ceR48-R53)

### Miscellaneous:
* Adjusted example code in `src/main.rs` to align with the updated type system and AST structure.