### PR TITLE
fix bugs and clean code

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,35 +1,5 @@
 extern crate lalrpop;
 
-use std::process::Command;
-
 fn main() {
-    //Generate parser with LALRPOP
     lalrpop::process_root().unwrap();
-
-    //Probe LLVM for host triple and data layout
-    let triple = Command::new("llvm-config")
-        .arg("--host-target")
-        .output()
-        .expect("Failed to run `llvm-config --host-target`; is llvm-config in your PATH?");
-    let datalayout = Command::new("llvm-config")
-        .arg("--data-layout")
-        .output()
-        .expect("Failed to run `llvm-config --data-layout`; is llvm-config in your PATH?");
-
-    //Convert to UTF-8 and trim newlines
-    let triple = String::from_utf8(triple.stdout)
-        .expect("`llvm-config --host-target` produced invalid UTF-8")
-        .trim()
-        .to_string();
-    let datalayout = String::from_utf8(datalayout.stdout)
-        .expect("`llvm-config --data-layout` produced invalid UTF-8")
-        .trim()
-        .to_string();
-
-    //Expose to Rust code via environment variables
-    println!("cargo:rustc-env=LLVM_HOST_TRIPLE={}", triple);
-    println!("cargo:rustc-env=LLVM_DATA_LAYOUT={}", datalayout);
-
-    //Invalidate build if build.rs itself changes
-    println!("cargo:rerun-if-changed=build.rs");
 }

--- a/src/ast_nodes/expression.rs
+++ b/src/ast_nodes/expression.rs
@@ -8,6 +8,7 @@ use super::block::{BlockNode, ExpressionList};
 use super::for_loop::ForNode;
 use super::let_in::{LetInNode,Assignment};
 use super::destructive_assign::DestructiveAssignNode;
+use crate::ast_nodes::print::PrintNode;
 use crate::ast_nodes::type_member_access::{TypeFunctionAccessNode, TypePropAccessNode};
 use crate::tokens::OperatorToken;
 use crate::visitor::accept::Accept;
@@ -32,6 +33,7 @@ pub enum Expression {
     TypeInstance(TypeInstanceNode),
     TypeFunctionAccess(TypeFunctionAccessNode),
     TypePropAccess(TypePropAccessNode),
+    Print(PrintNode)
 }
 
 impl Expression {
@@ -59,8 +61,8 @@ impl Expression {
         Expression::WhileLoop(WhileNode::new(condition, body))
     }
 
-    pub fn new_for_loop(variable: String, start: Expression, end: Expression, body: Expression) -> Self {
-        Expression::ForLoop(ForNode::new(variable, start, end, body))
+    pub fn new_for_loop(variable: String, iterable: Expression , body: Expression) -> Self {
+        Expression::ForLoop(ForNode::new(variable, iterable, body))
     }
 
     pub fn new_code_block(expression_list: ExpressionList) -> Self {
@@ -75,8 +77,8 @@ impl Expression {
         Expression::UnaryOp(UnaryOpNode::new(operator, operand))
     }
 
-    pub fn new_if_else(condition: Expression,then_expression: Expression,else_expression: Expression) -> Self {
-        Expression::IfElse(IfElseNode::new(condition, then_expression, else_expression))
+    pub fn new_if_else(condition: Expression, if_expression: Expression, elifs: Vec<(Option<Expression>, Expression)>) -> Self {
+        Expression::IfElse(IfElseNode::new(condition, if_expression, elifs))
     }
 
     pub fn new_let_in(assignments: Vec<Assignment>, body: Expression) -> Self {
@@ -98,7 +100,9 @@ impl Expression {
     pub fn new_type_prop_access(object: Expression, member: String) -> Self {
         Expression::TypePropAccess(TypePropAccessNode::new(object, member))
     }
-
+    pub fn new_print(expression: Expression) -> Self {
+        Expression::Print(PrintNode::new(expression))
+    }
 }
 
 impl Accept for Expression {
@@ -120,6 +124,7 @@ impl Accept for Expression {
             Expression::TypeInstance(node) => visitor.visit_type_instance(node),
             Expression::TypeFunctionAccess(node) => visitor.visit_type_function_access(node),
             Expression::TypePropAccess(node) => visitor.visit_type_prop_access(node),
+            Expression::Print(node) => visitor.visit_print(node)
         }
     }
 }

--- a/src/ast_nodes/for_loop.rs
+++ b/src/ast_nodes/for_loop.rs
@@ -3,18 +3,16 @@ use crate::{ast_nodes::expression::Expression, types_tree::tree_node::TypeNode};
 #[derive(Debug, PartialEq,Clone)]
 pub struct ForNode {
     pub variable: String,
-    pub start: Box<Expression>,
-    pub end: Box<Expression>,
+    pub iterable: Box<Expression>,
     pub body: Box<Expression>,
     pub node_type: Option<TypeNode>,
 }
 
 impl ForNode {
-    pub fn new(variable: String, start: Expression, end: Expression, body: Expression) -> Self {
+    pub fn new(variable: String, iterable:Expression, body: Expression) -> Self {
         ForNode {
             variable,
-            start: Box::new(start),
-            end: Box::new(end),
+            iterable: Box::new(iterable),
             body: Box::new(body),
             node_type: None,
         }

--- a/src/ast_nodes/if_else.rs
+++ b/src/ast_nodes/if_else.rs
@@ -6,17 +6,17 @@ use super::expression::Expression;
 #[derive(Debug, PartialEq,Clone)]
 pub struct IfElseNode {
     pub condition: Box<Expression>,
-    pub then_expression: Box<Expression>,
-    pub else_expression: Box<Expression>,
+    pub if_expression: Box<Expression>,
+    pub elifs: Vec<(Option<Expression>,Expression)>,
     pub node_type: Option<TypeNode>,
 }
 
 impl IfElseNode {
-    pub fn new(condition: Expression,then_expression: Expression,else_expression: Expression) -> Self {
+    pub fn new(condition: Expression,if_expression: Expression,elifs: Vec<(Option<Expression>,Expression)>) -> Self {
         IfElseNode {
             condition: Box::new(condition),
-            then_expression: Box::new(then_expression),
-            else_expression: Box::new(else_expression),
+            if_expression: Box::new(if_expression),
+            elifs,
             node_type: None,
         }
     }

--- a/src/ast_nodes/mod.rs
+++ b/src/ast_nodes/mod.rs
@@ -14,3 +14,4 @@ pub mod destructive_assign;
 pub mod type_def;
 pub mod type_instance;
 pub mod type_member_access;
+pub mod print;

--- a/src/ast_nodes/print.rs
+++ b/src/ast_nodes/print.rs
@@ -1,0 +1,18 @@
+use crate::types_tree::tree_node::TypeNode;
+
+use super::expression::Expression;
+
+#[derive(Debug, PartialEq,Clone)]
+pub struct PrintNode {
+    pub expression: Box<Expression>,
+    pub node_type: Option<TypeNode>
+}
+
+impl PrintNode {
+    pub fn new(expression: Expression) -> Self {
+        PrintNode { expression:Box::new(expression), node_type: None }
+    }
+    pub fn set_type(&mut self, node_type: TypeNode) {
+        self.node_type = Some(node_type);
+    }
+}

--- a/src/codegen/llvm_utils.rs
+++ b/src/codegen/llvm_utils.rs
@@ -29,14 +29,9 @@ pub fn generate_printf(context: &mut CodeGenContext, value: &str, fmt: &str) {
 /// Emit the module header—ModuleID, data layout, and target triple—dynamically
 /// obtained from environment variables set by build.rs.
 pub fn generate_header(output: &mut Vec<String>) {
-    let datalayout = env::var("LLVM_DATA_LAYOUT")
-        .expect("LLVM_DATA_LAYOUT not set; did you run via Cargo with the build script?");
-    let triple = env::var("LLVM_HOST_TRIPLE")
-        .expect("LLVM_HOST_TRIPLE not set; did you run via Cargo with the build script?");
-
-    output.push(format!("; ModuleID = 'hulk'"));
-    output.push(format!(r#"target datalayout = "{}""#, datalayout));
-    output.push(format!(r#"target triple = "{}""#, triple));
+    output.push("; ModuleID = 'hulk'".into());
+    output.push("target datalayout = \"e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128\"".into());
+    output.push("target triple = \"x86_64-pc-linux-gnu\"".into());
 }
 
 /// Emit the `main` wrapper around the generated body.
@@ -57,4 +52,13 @@ pub fn generate_runtime_declarations(output: &mut Vec<String>) {
     output.push("declare double @fmod(double, double)".into());
     output.push("declare double @pow(double, double)".into());
     output.push("declare i8* @concat(i8*, i8*)".into());
+}
+
+pub fn to_llvm_type(type_node: String) -> String {
+    match type_node.as_str() {
+        "Number" => "double".to_string(),
+        "Boolean" => "i1".to_string(),
+        "String" => "i8*".to_string(),
+        _ => "i8*".to_string(), // Default to pointer type for unknown types
+    }
 }

--- a/src/codegen/visitor_codegen.rs
+++ b/src/codegen/visitor_codegen.rs
@@ -120,4 +120,8 @@ impl Visitor<String> for CodeGenerator {
     fn visit_type_prop_access(&mut self, _node: &mut TypePropAccessNode) -> String {
         unimplemented!()
     }
+    
+    fn visit_print(&mut self, _node: &mut crate::ast_nodes::print::PrintNode) -> String {
+        unimplemented!()
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,15 +8,36 @@ pub mod types_tree;
 pub mod visitor;
 use crate::visitor::printer_visitor::PrinterVisitor;
 
-pub mod codegen;
-use crate::codegen::CodeGenerator;
-
 lalrpop_mod!(pub parser);
 
-const RUNTIME_C: &str = "runtime.c";
-
 fn main() {
-    let input = "5+5";
+    let input = "
+    type Person (name: String , edad: Number) {
+        name = name;
+        edad = edad;
+
+        getName(): String => self.name;
+        getEdad(): String => self.edad;
+
+    };
+
+    print(new Person(\"Diego\", 22));
+
+    function loca(a: Number): String {
+        let b = 5 in (b @ \"Hello world\");
+    } ;
+
+    if ( 5 > 4 ) {
+        5
+    } else {
+        \"canchanfleta una pera\"
+    };
+
+    let a = 20 in {
+        let a = 42 in print(a);
+        print(a);
+    } ;
+    ";
 
     let mut expr = parser::ProgramParser::new().parse(input).unwrap();
 
@@ -28,57 +49,6 @@ fn main() {
     match result {
         Ok(_) => {
             println!("Semantic Analyzer OK");
-
-            // Generate code after semantic analysis
-            println!("\nGenerating LLVM IR...");
-            let mut codegen = CodeGenerator::new();
-            let llvm_ir = codegen.generate(&mut expr);
-
-            // Print in green
-            println!("\x1b[32mGenerated LLVM IR:\n{}\x1b[0m", llvm_ir);
-
-            // Write to file
-            std::fs::write("output.ll", &llvm_ir).expect("Failed to write LLVM IR");
-            println!("LLVM IR written to output.ll");
-
-            // Compile and run
-            println!("\nCompiling and running...");
-
-            // Compile with runtime.c and math library
-            let compile_status = std::process::Command::new("clang")
-                .args(&["output.ll", RUNTIME_C, "-lm", "-o", "output"])
-                .status()
-                .expect("Failed to compile with clang");
-
-            if compile_status.success() {
-                // Run the compiled program
-                let run_output = std::process::Command::new("./output")
-                    .output()
-                    .expect("Failed to run program");
-
-                if run_output.status.success() {
-                    println!(
-                        "\x1b[34mProgram output:\n{}\x1b[0m",
-                        String::from_utf8_lossy(&run_output.stdout)
-                    );
-                } else {
-                    eprintln!(
-                        "\x1b[31mProgram execution failed:\n{}\x1b[0m",
-                        String::from_utf8_lossy(&run_output.stderr)
-                    );
-                }
-            } else {
-                // Capture clang error output
-                let clang_output = std::process::Command::new("clang")
-                    .args(&["output.ll", RUNTIME_C, "-lm", "-o", "output"])
-                    .output()
-                    .expect("Failed to run clang");
-
-                eprintln!(
-                    "\x1b[31mCompilation failed:\n{}\x1b[0m",
-                    String::from_utf8_lossy(&clang_output.stderr)
-                );
-            }
         }
         Err(errors) => {
             println!("\x1b[31mErrors:");
@@ -88,8 +58,6 @@ fn main() {
             println!("\x1b[0m");
         }
     }
-
     println!("");
-    // Print AST in blue
     println!("\x1b[34mAST:\n{}\x1b[0m", printer.print_program(&mut expr));
 }

--- a/src/parser.lalrpop
+++ b/src/parser.lalrpop
@@ -16,7 +16,7 @@ use crate::ast_nodes::function_call::FunctionCallNode;
 grammar;
 
 pub Program: Program = {
-    <v:(<Statement> Semicolon)*> <last:Statement?> => {
+    <v:(<Statement> Semicolon)*> <last:Statement?> Semicolon  => {
         let mut vec = v;
         if let Some(e) = last {
             vec.push(e);
@@ -118,8 +118,8 @@ TypePropAccess: Expression = {
 };
 
 Expr: Expression = { 
-    DestructiveAssignExpr,
-    LogicalOrExpr
+    DestructiveAssignExpr ,
+    LogicalOrExpr 
 };
 
 DestructiveAssignExpr: Expression = {
@@ -250,27 +250,21 @@ WhileLoop: Expression = {
 
 //Maybe catch these errors in a different place (Like Semantic Analysis)
 ForLoop: Expression = {
-    For LParen <id:Identifier> In <call:CompositeExpr> RParen <body:CompositeExpr> => {
-        if let Expression::FunctionCall(func_call) = call {
-            if func_call.function_name == "range" && func_call.arguments.len() == 2 {
-                let mut args = func_call.arguments;
-                let start = args.remove(0);
-                let end = args.remove(0);
-                
-                Expression::new_for_loop(id, start, end, body)
-            } else {
-                panic!("For loop must use `range` with exactly two arguments");
-            }
-        } else {
-            panic!("For loop iterable must be a `range` function call");
-        }
-    }
+    For LParen <id:Identifier> In <call:CompositeExpr> RParen <body:CompositeExpr> => Expression::new_for_loop(id, call, body)
 };
 
 IfElse: Expression = {
-    If LParen <condition:Expr> RParen <if_body:CompositeExpr> Else <else_body:CompositeExpr> => {
-        Expression::new_if_else(condition,if_body,else_body)
-    },
+    If LParen <condition:Expr> RParen <if_body:CodeBlock> => Expression::new_if_else(condition,if_body,Vec::new()),
+    If LParen <condition:Expr> RParen <if_body:CodeBlock> <else_or_elif:ElseOrElif> => Expression::new_if_else(condition, if_body, else_or_elif)
+}
+
+ElseOrElif: Vec<(Option<Expression>,Expression)> = {
+    Else <else_expr:CodeBlock> => vec![(None,else_expr)],
+    Elif LParen <cond:Expr> RParen <body:CodeBlock> <rest:ElseOrElif> => {
+        let mut exprs = vec![(Some(cond),body)];
+        exprs.extend(rest);
+        return exprs;
+    }
 }
 
 CompositeExpr: Expression = {
@@ -293,7 +287,7 @@ PrimaryExpr: Expression = {
     True => Expression::new_boolean(true),
     False => Expression::new_boolean(false),
     CodeBlock,
-    
+    PrintExpr,
 };
 
 Identifier: String = {
@@ -308,9 +302,9 @@ Str: String = {
     r#""([^"\\]|\\.)*""# => String::from_str(&<>[1..<>.len()-1]).unwrap(),
 };
 
-// PrintExpr: Box<Expr> = {
-//     Print LParen <Expr> RParen => Box::new(Expr::Print(<>)),
-// };
+PrintExpr: Expression = {
+    Print LParen <Expr> RParen => Expression::new_print(<>),
+};
 
 UnaryOp: OperatorToken = {
     "!" => OperatorToken::NOT,
@@ -441,9 +435,9 @@ New: KeywordToken = {
     "new" => KeywordToken::NEW,
 };
 
-// Print: KeywordToken = {
-//     "print" => KeywordToken::PRINT,
-// };
+Print: KeywordToken = {
+    "print" => KeywordToken::PRINT,
+};
 
 True: KeywordToken = {
     "true" => KeywordToken::TRUE,

--- a/src/semantic_analyzer/semantic_errors.rs
+++ b/src/semantic_analyzer/semantic_errors.rs
@@ -23,6 +23,8 @@ pub enum SemanticError {
     InvalidTypeFunctionAccess(String,String),
     InvalidTypePropertyAccess(String,String),
     InvalidTypeProperty(String, String),
+    InvalidPrint(String),
+    InvalidIterable(String,usize),
 }
 
 impl SemanticError {
@@ -91,6 +93,12 @@ impl SemanticError {
             }
             SemanticError::InvalidTypeProperty(type_name, property_name) => {
                 format!("Error: type {} does not have a property named {}.", type_name, property_name)
+            }
+            SemanticError::InvalidPrint(type_name) => {
+                format!("Error: type {} cannot be printed.", type_name)
+            }
+            SemanticError::InvalidIterable(func_name, arg_count) => {
+                format!("Error: for only accpets range(x,y) iterable function, function {} with {} arguments was found.", func_name,arg_count)
             }
         }
     }

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 #[derive(Debug, PartialEq,Clone)]
 pub enum KeywordToken {
-    //PRINT,
+    PRINT,
     WHILE,
     FOR,
     ELIF,

--- a/src/visitor/visitor_trait.rs
+++ b/src/visitor/visitor_trait.rs
@@ -2,6 +2,7 @@ use crate::ast_nodes::binary_op::BinaryOpNode;
 use crate::ast_nodes::destructive_assign::DestructiveAssignNode;
 use crate::ast_nodes::for_loop::ForNode;
 use crate::ast_nodes::function_call::FunctionCallNode;
+use crate::ast_nodes::print::PrintNode;
 use crate::ast_nodes::type_def::TypeDefNode;
 use crate::ast_nodes::unary_op::UnaryOpNode;
 use crate::ast_nodes::if_else::IfElseNode;
@@ -32,4 +33,5 @@ pub trait Visitor<T> {
     fn visit_type_instance(&mut self, node: &mut TypeInstanceNode) -> T;
     fn visit_type_function_access(&mut self, node: &mut TypeFunctionAccessNode) -> T;
     fn visit_type_prop_access(&mut self, node: &mut TypePropAccessNode) -> T;
+    fn visit_print(&mut self, node: &mut PrintNode) -> T;
 }


### PR DESCRIPTION
This pull request introduces several changes to the codebase, focusing on simplifying the build process, enhancing the Abstract Syntax Tree (AST) with new features, and improving semantic analysis. The most significant updates include removing LLVM host triple and data layout probing, adding support for `print` expressions, refactoring `for` and `if-else` constructs, and enhancing semantic validation for `for` loops.

### Build Process Simplification:
* [`build.rs`](diffhunk://#diff-d0d98998092552a1d3259338c2c71e118a5b8343dd4703c0c7f552ada7f9cb42L3-L34): Removed LLVM host triple and data layout probing logic, simplifying the build script and eliminating reliance on environment variables.
* [`src/codegen/llvm_utils.rs`](diffhunk://#diff-c37ef67dc832ae3a934a9f2f04efa355cdb4e04d04d4c7bc9b4e1c930505554eL32-R34): Hardcoded target triple and data layout in the `generate_header` function, removing dynamic generation via environment variables.

### AST Enhancements:
* [`src/ast_nodes/expression.rs`](diffhunk://#diff-3d16cd20f9c16cd9c6d124bcda24d45bdb0d05ed0ea05a90e90b9e105e521962R11): Added `PrintNode` to the `Expression` enum and implemented methods for creating `print` expressions. [[1]](diffhunk://#diff-3d16cd20f9c16cd9c6d124bcda24d45bdb0d05ed0ea05a90e90b9e105e521962R11) [[2]](diffhunk://#diff-3d16cd20f9c16cd9c6d124bcda24d45bdb0d05ed0ea05a90e90b9e105e521962R36) [[3]](diffhunk://#diff-3d16cd20f9c16cd9c6d124bcda24d45bdb0d05ed0ea05a90e90b9e105e521962L101-R105) [[4]](diffhunk://#diff-b12268da5b4824b54e95ff19307f2e0641c6b871ebb7f8dcffede68a5244ae93R123-R126)
* [`src/parser.lalrpop`](diffhunk://#diff-e54fbaba2e815faa0451f69cf4dede45a89f11e71c5ab14e406aa923c6902de7L296-R290): Added grammar rules for `print` expressions and updated the `PrimaryExpr` production. [[1]](diffhunk://#diff-e54fbaba2e815faa0451f69cf4dede45a89f11e71c5ab14e406aa923c6902de7L296-R290) [[2]](diffhunk://#diff-e54fbaba2e815faa0451f69cf4dede45a89f11e71c5ab14e406aa923c6902de7L311-R307)

### Refactoring Constructs:
* [`src/ast_nodes/expression.rs`](diffhunk://#diff-3d16cd20f9c16cd9c6d124bcda24d45bdb0d05ed0ea05a90e90b9e105e521962L62-R65): Refactored `new_for_loop` to use an iterable expression instead of `start` and `end` parameters. Updated `new_if_else` to support `elif` branches. [[1]](diffhunk://#diff-3d16cd20f9c16cd9c6d124bcda24d45bdb0d05ed0ea05a90e90b9e105e521962L62-R65) [[2]](diffhunk://#diff-3d16cd20f9c16cd9c6d124bcda24d45bdb0d05ed0ea05a90e90b9e105e521962L78-R81)
* [`src/parser.lalrpop`](diffhunk://#diff-e54fbaba2e815faa0451f69cf4dede45a89f11e71c5ab14e406aa923c6902de7L253-R267): Updated grammar rules for `for` loops to use iterable expressions and added support for `elif` branches in `if-else` constructs. [[1]](diffhunk://#diff-e54fbaba2e815faa0451f69cf4dede45a89f11e71c5ab14e406aa923c6902de7L253-R267) [[2]](diffhunk://#diff-e54fbaba2e815faa0451f69cf4dede45a89f11e71c5ab14e406aa923c6902de7L444-R440)

### Semantic Analysis Improvements:
* [`src/semantic_analyzer/semantic_analyzer.rs`](diffhunk://#diff-ccd0aec5b8e3d1a5e92f49aa99f8f577a931fc5afb1965d2c6e54c7affb55919L175-R195): Enhanced semantic validation for `for` loops to ensure the iterable is a `range` function call with two numeric arguments. Added predefined constants (`PI` and `E`) to the symbol table. [[1]](diffhunk://#diff-ccd0aec5b8e3d1a5e92f49aa99f8f577a931fc5afb1965d2c6e54c7affb55919L175-R195) [[2]](diffhunk://#diff-ccd0aec5b8e3d1a5e92f49aa99f8f577a931fc5afb1965d2c6e54c7affb55919L47-R52)

These changes collectively improve the maintainability and functionality of the codebase while introducing new capabilities for handling `print` expressions and enhancing semantic validation.