### PR TITLE
feat: add another test for lexer

### DIFF
--- a/src/lexer_generator/src/test/test_lexer.rs
+++ b/src/lexer_generator/src/test/test_lexer.rs
@@ -142,3 +142,42 @@ pub fn lex_another_hulk_line_with_error() {
         "Lexical Error!: Unexpected character '#' at line: 0, column: 18"
     );
 }
+
+#[test]
+pub fn lex_another_hulk_line_with_multiple_errors() {
+    let rules = vec![
+        TokenSpec::build("EQUAL", r"="),
+        TokenSpec::build("FUNCTION", r"function"),
+        TokenSpec::build("ARROW", r"=>"),
+        TokenSpec::build("SEMICOLON", r";"),
+        TokenSpec::build("COLON", r":"),
+        TokenSpec::build("PLUS", r"\+"),
+        TokenSpec::build("LPAREN", r"\("),
+        TokenSpec::build("RPAREN", r"\)"),
+        TokenSpec::build("COMMA", r","),
+        TokenSpec::build("IDENTIFIER", r"(_|[a-zA-Z])(_|[a-z0-9A-Z])*"),
+        TokenSpec::build_ignorable("WhiteSpace", r"(\s|\t|\n)+"),
+    ];
+
+    let lexer = Lexer::new(rules);
+    let input =
+"function 2a () => b $ c;
+function testicol () => d + e;
+function minus() => f - g;";
+
+    let result = lexer.split(input);
+
+    assert!(result.is_err());
+
+    let errors = result.err().unwrap();
+
+    assert_eq!(errors.len(), 3);
+    assert_eq!(
+        errors,
+        vec![
+            "Lexical Error!: Unexpected character '2' at line: 0, column: 9",
+            "Lexical Error!: Unexpected character '$' at line: 0, column: 20",
+            "Lexical Error!: Unexpected character '-' at line: 4, column: 23"
+        ]
+    );
+}


### PR DESCRIPTION
This pull request adds a new test function to the lexer test suite to validate handling of multiple lexical errors in a single input string.

### Enhancements to lexer testing:

* [`src/lexer_generator/src/test/test_lexer.rs`](diffhunk://#diff-d50ee94cae8ff9c1f8b86864c2ff3a28068f2c6a42ba50bdf67ff28d4889670aR145-R183): Added the `lex_another_hulk_line_with_multiple_errors` test function to ensure the lexer correctly identifies and reports multiple lexical errors within a single input. The test verifies error messages for unexpected characters ('2', ', and '-') at specific locations in the input string.