### PR TITLE
fix bug SA function return undefined

### DIFF
--- a/src/semantic_analyzer/semantic_analyzer.rs
+++ b/src/semantic_analyzer/semantic_analyzer.rs
@@ -104,8 +104,11 @@ impl SemanticAnalyzer {
                         if self.context.declared_functions.contains_key(&node.name) {
                             self.new_error(SemanticError::RedefinitionOfFunction(node.name.clone()));
                         } else {
-
-                            self.context.declared_functions.insert(node.name.clone(), FunctionInfo::new(node.name.clone(), arg_types.clone(),self.types_tree.get_type(&func_return).unwrap().type_name));
+                            if let Some(func_type) = self.types_tree.get_type(&func_return) {
+                                self.context.declared_functions.insert(node.name.clone(), FunctionInfo::new(node.name.clone(), arg_types.clone(), func_type.type_name));
+                            } else {
+                                self.context.declared_functions.insert(node.name.clone(), FunctionInfo::new(node.name.clone(), arg_types.clone(), self.get_built_in_types(&BuiltInTypes::Unknown).type_name));
+                            }
                         }
                     },
                     _ => continue ,


### PR DESCRIPTION
This pull request updates the `SemanticAnalyzer` in `src/semantic_analyzer/semantic_analyzer.rs` to improve error handling and robustness when defining functions. The change ensures that if the return type of a function is not found, a default "Unknown" type is used instead of potentially causing a runtime error.

Enhancements to error handling and robustness:

* [`src/semantic_analyzer/semantic_analyzer.rs`](diffhunk://#diff-ccd0aec5b8e3d1a5e92f49aa99f8f577a931fc5afb1965d2c6e54c7affb55919L107-R111): Modified the logic in `impl SemanticAnalyzer {` to check if the return type of a function exists in the type tree. If not, it assigns a default "Unknown" type using `self.get_built_in_types(&BuiltInTypes::Unknown)` to prevent runtime issues.