### PR TITLE
added codegen for loop

### DIFF
--- a/src/ast_nodes/expression.rs
+++ b/src/ast_nodes/expression.rs
@@ -61,8 +61,8 @@ impl Expression {
         Expression::WhileLoop(WhileNode::new(condition, body))
     }
 
-    pub fn new_for_loop(variable: String, iterable: Expression , body: Expression) -> Self {
-        Expression::ForLoop(ForNode::new(variable, iterable, body))
+    pub fn new_for_loop(variable: String, start: Expression , end: Expression, body: Expression) -> Self {
+        Expression::ForLoop(ForNode::new(variable, start, end, body))
     }
 
     pub fn new_code_block(expression_list: ExpressionList) -> Self {

--- a/src/ast_nodes/for_loop.rs
+++ b/src/ast_nodes/for_loop.rs
@@ -3,16 +3,18 @@ use crate::{ast_nodes::expression::Expression, types_tree::tree_node::TypeNode};
 #[derive(Debug, PartialEq,Clone)]
 pub struct ForNode {
     pub variable: String,
-    pub iterable: Box<Expression>,
+    pub start: Box<Expression>,
+    pub end: Box<Expression>,
     pub body: Box<Expression>,
     pub node_type: Option<TypeNode>,
 }
 
 impl ForNode {
-    pub fn new(variable: String, iterable:Expression, body: Expression) -> Self {
+    pub fn new(variable: String, start: Expression, end: Expression, body: Expression) -> Self {
         ForNode {
             variable,
-            iterable: Box::new(iterable),
+            start: Box::new(start),
+            end: Box::new(end),
             body: Box::new(body),
             node_type: None,
         }

--- a/src/parser.lalrpop
+++ b/src/parser.lalrpop
@@ -249,7 +249,7 @@ WhileLoop: Expression = {
 };
 
 ForLoop: Expression = {
-    For LParen <id:Identifier> In <call:CompositeExpr> RParen <body:CompositeExpr> => Expression::new_for_loop(id, call, body)
+    For LParen <id:Identifier> In "range" LParen <start:Expr> Comma <end:Expr> RParen RParen <body:CompositeExpr> => Expression::new_for_loop(id, start, end, body)
 };
 
 IfElse: Expression = {

--- a/src/visitor/printer_visitor.rs
+++ b/src/visitor/printer_visitor.rs
@@ -66,9 +66,10 @@ impl Visitor<String> for PrinterVisitor {
     }
     fn visit_for_loop(&mut self, node: &mut ForNode) -> String {
         let variable = &node.variable;
-        let iterable = node.iterable.accept(self);
+        let start = node.start.accept(self);
+        let end = node.end.accept(self);
         let body = node.body.accept(self);
-        format!("for ({} in {}) {{\n{}\n}}", variable, iterable , body)
+        format!("for ({} in range({}, {})) {{\n{}\n}}", variable, start, end, body)
     }
     fn visit_code_block(&mut self, node: &mut BlockNode) -> String {
         let expressions: Vec<String> = node.expression_list.expressions.iter_mut()


### PR DESCRIPTION
This pull request refactors the implementation of `ForLoop` in the codebase to replace the previous iterable-based design with a range-based design, using explicit `start` and `end` expressions. This change affects the Abstract Syntax Tree (AST), code generation, semantic analysis, and printing functionality. The most important changes include updates to the `ForNode` structure, adjustments to the parser to accommodate the new syntax, and modifications to the code generation and semantic analysis logic.

### Refactoring `ForLoop` to use ranges:

#### Changes to the AST:
* [`src/ast_nodes/expression.rs`](diffhunk://#diff-3d16cd20f9c16cd9c6d124bcda24d45bdb0d05ed0ea05a90e90b9e105e521962L64-R65): Updated the `new_for_loop` method to accept `start` and `end` expressions instead of an iterable.
* [`src/ast_nodes/for_loop.rs`](diffhunk://#diff-d0b63e963cb55381f4fb88fd1734fea2b02946144085c322a5ffc9153b646463L6-R17): Modified the `ForNode` structure to replace the `iterable` field with `start` and `end` fields, and updated its constructor accordingly.

#### Parser updates:
* [`src/parser.lalrpop`](diffhunk://#diff-e54fbaba2e815faa0451f69cf4dede45a89f11e71c5ab14e406aa923c6902de7L252-R252): Adjusted the `ForLoop` parsing rule to use the new range syntax (`range(start, end)`) instead of an iterable.

#### Code generation logic:
* [`src/codegen/visitor_codegen.rs`](diffhunk://#diff-b12268da5b4824b54e95ff19307f2e0641c6b871ebb7f8dcffede68a5244ae93L154-R224): Implemented code generation for the new range-based `ForLoop`, including logic for loop initialization, condition checking, and variable stepping.

#### Semantic analysis updates:
* [`src/semantic_analyzer/semantic_analyzer.rs`](diffhunk://#diff-ccd0aec5b8e3d1a5e92f49aa99f8f577a931fc5afb1965d2c6e54c7affb55919L185-R191): Updated the semantic analysis logic to validate the types of `start` and `end` expressions, ensuring they are `Number`. Removed the previous iterable validation logic.

#### Printing functionality:
* [`src/visitor/printer_visitor.rs`](diffhunk://#diff-851053216aaa2219403de9126115861b9755a658b08ebc5d78295919e19ead27L69-R72): Updated the `visit_for_loop` method to generate code for the new range-based syntax (`for (variable in range(start, end))`).