### PR TITLE
mpv for builtin functions, rand still doesn't work, line offset fixed

### DIFF
--- a/src/builtin/function_injector.rs
+++ b/src/builtin/function_injector.rs
@@ -1,0 +1,161 @@
+pub struct FunctionInjector {
+    builtin_functions_code: String,
+}
+
+impl FunctionInjector {
+    pub fn new() -> Self {
+        Self {
+            builtin_functions_code: String::from(
+                "
+                function abs(x:Number):Number{
+                    if (x < 0){
+                        -x;
+                    }
+                    else{
+                        x;
+                    }
+                };
+
+                function sqrt(x:Number):Number {
+                    if (x < 0){
+                        -1;
+                    }
+                    elif (x == 0){
+                        0;
+                    }
+                    else{
+                        let epsilon = 0.0000000001 in
+                        let prev = x, guess = x / 2.0, first = true in
+                        while (first | (abs(guess - prev) > epsilon)) {
+                            first := false;
+                            prev := guess;
+                            guess := (guess + x / guess) / 2.0;
+                        }
+                    }
+                };
+
+                function exp(x: Number): Number {
+                    if (x == 0) {
+                        1;
+                    } else {
+                        let abs_x = abs(x) in
+                        let result = 0, term = 1, n = 1, iter = 0, epsilon = 0.0000000001, max_iter = 1000 in {
+                            while ((term >= epsilon) & (iter < max_iter)) {
+                                result := result + term;
+                                term := term * abs_x / n;
+                                n := n + 1;
+                                iter := iter + 1;
+                            };
+                            if (x < 0) {
+                                1 / result;
+                            } else {
+                                result;
+                            }
+                        }
+                    }
+                };
+
+                function sin(x: Number): Number {
+                    let two_pi = 2 * PI in
+                    let reduced_x = x in {
+                        while (reduced_x > two_pi) {
+                            reduced_x := reduced_x - two_pi;
+                        };
+                        while (reduced_x < -two_pi) {
+                            reduced_x := reduced_x + two_pi;
+                        };
+                        let result = 0.0, term = reduced_x, n = 0, epsilon = 0.0000000001, max_iter = 1000 in {
+                            while ((abs(term) >= epsilon) & (n < max_iter)) {
+                                result := result + term;
+                                n := n + 1;
+                                term := term * (-1) * reduced_x * reduced_x / ((2 * n) * (2 * n + 1));
+                            };
+                            result;
+                        }
+                    }
+                };
+
+                function cos(x: Number): Number {
+                    let two_pi = 2 * PI in
+                    let reduced_x = x in {
+                        while (reduced_x > two_pi) {
+                            reduced_x := reduced_x - two_pi;
+                        };
+                        while (reduced_x < -two_pi) {
+                            reduced_x := reduced_x + two_pi;
+                        };
+                        let result = 0.0, term = 1, n = 0, epsilon = 0.0000000001, max_iter = 1000 in {
+                            while ((abs(term) >= epsilon) & (n < max_iter)) {
+                                result := result + term;
+                                n := n + 1;
+                                term := term * (-1) * reduced_x * reduced_x / ((2 * n - 1) * (2 * n));
+                            };
+                            result;
+                        }
+                    }
+                };
+
+                function log10(x: Number): Number {
+                    if (x <= 0) {
+                        0;
+                    } else {
+                        let int_part = 0 in
+                        let temp = x in {
+                            while (temp >= 10) {
+                                temp := temp / 10;
+                                int_part := int_part + 1;
+                            };
+                            
+                            while (temp < 1) {
+                                temp := temp * 10;
+                                int_part := int_part - 1;
+                            };
+                            
+                            let y = (temp - 1) / (temp + 1) in
+                            let y2 = y * y in
+                            let frac = 0.0, term = y, n = 0, epsilon = 0.0000000001, max_iter = 1000 in {
+                                while ((abs(term) >= epsilon) & (n < max_iter)) {
+                                    frac := frac + term;
+                                    n := n + 1;
+                                    term := term * y2 * (2 * n - 1) / (2 * n + 1);
+                                };
+                                let fractional = 0.8685889638065035 * 2 * frac in
+                                    (int_part + fractional);
+                            }
+                        }
+                    }
+                };
+
+                function log(base: Number, value: Number): Number {
+                    if (base <= 0 | value <= 0) {
+                        0;
+                    } else {
+                        log10(value) / log10(base);
+                    }
+                };
+
+                function rand(): Number {
+                    let seed = (PI * 1000000000) - 3141592653 in
+                    let a = 1664525 in
+                    let c = 1013904223 in
+                    let m = 4294967296 in 
+                    let new_seed = ((a * seed + c) % m) in
+                    (new_seed / m);
+                };
+                ",
+            ),
+        }
+    }
+
+    pub fn get_builtin_functions_code(&self) -> &str {
+        &self.builtin_functions_code
+    }
+
+    pub fn get_builtin_functions_code_lines(&self) -> usize {
+        self.builtin_functions_code.lines().count()
+    }
+
+    pub fn inject_code(&self, input: &str) -> String {
+        format!("{}\n{}", self.builtin_functions_code, input)
+    }
+}

--- a/src/builtin/mod.rs
+++ b/src/builtin/mod.rs
@@ -1,0 +1,3 @@
+pub mod function_injector;
+
+pub use function_injector::FunctionInjector;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,43 +1,35 @@
-use crate::semantic_analyzer::semantic_analyzer::SemanticAnalyzer;
+use crate::{parser_w_errors::Parser, semantic_analyzer::semantic_analyzer::SemanticAnalyzer};
 use lalrpop_util::lalrpop_mod;
 pub mod ast_nodes;
+pub mod builtin;
+pub mod codegen;
 mod parser_w_errors;
 pub mod semantic_analyzer;
-pub mod codegen;
 mod tokens;
 pub mod types_tree;
 pub mod visitor;
 
 lalrpop_mod!(pub parser);
 
-use crate::parser_w_errors::Parser;
+use crate::builtin::FunctionInjector;
 use codegen::CodeGenerator;
 
 fn main() {
-    let input = r#"
-        for (pene in range(1,5)){
-            let a = "sexo" in {
-                let b = a @ " muy fuerte" in { 
-                    let c = b @ " y muy duro" in {
-                        print(c); 
-                    };
-                };
-            };
-            print( pene );
-        };
-        
-    "#;
+    let raw_input = r#"exp(5);"#;
 
-     let parser = Parser::new();
-    match parser.parse(input) {
+    let function_injector = FunctionInjector::new();
+    let input = function_injector.inject_code(raw_input);
+    let missplacement = function_injector.get_builtin_functions_code_lines() as i32;
+
+    let parser = Parser::new(missplacement);
+    match parser.parse(&input) {
         Ok(mut expr) => {
-            println!("\x1b[32mSyntactic Analyzer OK\x1b[0m");
-            println!("\x1b[0m");
+            println!("Syntactic Analyzer OK");
             let mut semantic_analyzer = SemanticAnalyzer::new();
             let result = semantic_analyzer.analyze(&mut expr);
             match result {
                 Ok(_) => {
-                    println!("\x1b[32mSemantic Analyzer OK\x1b[0m");
+                    println!("Semantic Analyzer OK");
                 }
                 Err(errors) => {
                     println!("\x1b[31mSemantic Errors:");


### PR DESCRIPTION
This pull request introduces a new `FunctionInjector` module for injecting built-in functions into code and modifies the parser to account for line offsets caused by the injected code. The changes improve functionality by enabling built-in mathematical and utility functions, while ensuring accurate error reporting in the parser.

### Built-in Function Injection:

* [`src/builtin/function_injector.rs`](diffhunk://#diff-d3fc7d07a50e510518cef053b63f2dad7a3fa5db216aaf40311dee2e85fdc1fdR1-R161): Added the `FunctionInjector` struct, which contains built-in functions like `abs`, `sqrt`, `exp`, `sin`, `cos`, `log10`, `log`, and `rand`. These functions are injected into the input code for use during parsing.
* [`src/builtin/mod.rs`](diffhunk://#diff-4b02c2f1acc9a3e733e7c266cf6f1f29b4ea85cc379383afc0c51114d46d1f94R1-R3): Created a new module `builtin` and exposed `FunctionInjector` for external use.

### Parser Enhancements:

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL1-R32): Integrated `FunctionInjector` into the main application flow. The injected code is added to the raw input, and the parser now accounts for the number of lines in the injected code (`missplacement`) to adjust error reporting.
* [`src/parser_w_errors.rs`](diffhunk://#diff-ecdb33f1e605f48ff1f92bbe3e22d1f652185aaec8f13331f06ed8d28536333eR10-R20): Updated the `Parser` struct to include a `missplacement` field and modified methods like `offset_to_line_col` to adjust line numbers based on the injected code. This ensures accurate syntax error reporting. [[1]](diffhunk://#diff-ecdb33f1e605f48ff1f92bbe3e22d1f652185aaec8f13331f06ed8d28536333eR10-R20) [[2]](diffhunk://#diff-ecdb33f1e605f48ff1f92bbe3e22d1f652185aaec8f13331f06ed8d28536333eL38-L82) [[3]](diffhunk://#diff-ecdb33f1e605f48ff1f92bbe3e22d1f652185aaec8f13331f06ed8d28536333eL99-R69) [[4]](diffhunk://#diff-ecdb33f1e605f48ff1f92bbe3e22d1f652185aaec8f13331f06ed8d28536333eL128-R90) [[5]](diffhunk://#diff-ecdb33f1e605f48ff1f92bbe3e22d1f652185aaec8f13331f06ed8d28536333eL150-R112)