### PR TITLE
feat: built-in functions integrated on cg

### DIFF
--- a/src/codegen/code_generator.rs
+++ b/src/codegen/code_generator.rs
@@ -18,7 +18,7 @@ impl CodeGenerator {
     pub fn generate(&mut self, program: &mut Program) -> String {
         let mut module_code: Vec<String> = vec![];
         generate_header(&mut module_code);
-        declare_printf(&mut module_code);
+        declare_printf(&mut module_code, &mut self.context);
         generate_runtime_declarations(&mut module_code);
         module_code.push("".into());
 

--- a/src/codegen/context.rs
+++ b/src/codegen/context.rs
@@ -10,6 +10,7 @@ pub enum Type {
 pub struct CodeGenContext {
     pub code: Vec<String>,
     pub globals: Vec<String>,
+    pub global_constants: HashSet<String>,
     pub str_constants: Vec<String>,
     pub temp_counter: usize,
     pub id: usize,
@@ -33,6 +34,7 @@ impl Default for CodeGenContext {
         Self {
             code: Vec::new(),
             globals: Vec::new(),
+            global_constants: HashSet::new(),
             str_constants: Vec::new(),
             temp_counter: 1,
             id: 1,
@@ -69,6 +71,13 @@ impl CodeGenContext {
         result.extend(std::mem::take(&mut self.globals));
         result.extend(std::mem::take(&mut self.code));
         result
+    }
+    pub fn add_global_constant(&mut self, name: &str) {
+        self.global_constants.insert(name.to_string());
+    }
+    
+    pub fn is_global_constant(&self, name: &str) -> bool {
+        self.global_constants.contains(name)
     }
 
     pub fn take_globals(&mut self) -> Vec<String> {

--- a/src/codegen/llvm_utils.rs
+++ b/src/codegen/llvm_utils.rs
@@ -1,7 +1,11 @@
 use super::context::CodeGenContext;
 
 /// Emit the global string constants and the printf declaration.
-pub fn declare_printf(output: &mut Vec<String>) {
+pub fn declare_printf(output: &mut Vec<String>,  context: &mut CodeGenContext) {
+    output.push("@PI = constant double 0x400921FB54442D18".into()); // π
+    output.push("@E = constant double 0x4005BF0A8B145769".into()); // e
+    context.add_global_constant("PI");
+    context.add_global_constant("E");
     output.push(r#"@.str.f = private unnamed_addr constant [4 x i8] c"%f\0A\00", align 1"#.into());
     output.push(r#"@.str.d = private unnamed_addr constant [4 x i8] c"%d\0A\00", align 1"#.into());
     output.push(r#"@.str.s = private unnamed_addr constant [4 x i8] c"%s\0A\00", align 1"#.into());


### PR DESCRIPTION
This pull request introduces enhancements to the code generation system by adding support for global constants, improving the handling of identifiers, and updating operator handling. The changes primarily focus on extending the functionality of the `CodeGenContext` and refining the visitor pattern in `CodeGenerator`.

### Enhancements to global constants:

* [`src/codegen/context.rs`](diffhunk://#diff-672a976253ed978c80097497bed31f10167638ef6987dc7cc9bfa8d345aac031R13): Introduced a `global_constants` field in `CodeGenContext` as a `HashSet<String>` and added methods `add_global_constant` and `is_global_constant` to manage global constants. Updated the default implementation to initialize this field. [[1]](diffhunk://#diff-672a976253ed978c80097497bed31f10167638ef6987dc7cc9bfa8d345aac031R13) [[2]](diffhunk://#diff-672a976253ed978c80097497bed31f10167638ef6987dc7cc9bfa8d345aac031R37) [[3]](diffhunk://#diff-672a976253ed978c80097497bed31f10167638ef6987dc7cc9bfa8d345aac031R75-R81)
* [`src/codegen/llvm_utils.rs`](diffhunk://#diff-c37ef67dc832ae3a934a9f2f04efa355cdb4e04d04d4c7bc9b4e1c930505554eL4-R8): Modified `declare_printf` to accept a `CodeGenContext` and added global constants `PI` and `E` with their respective LLVM representations.

### Improved handling of identifiers:

* [`src/codegen/visitor_codegen.rs`](diffhunk://#diff-b12268da5b4824b54e95ff19307f2e0641c6b871ebb7f8dcffede68a5244ae93R88-R104): Enhanced `visit_identifier` to check if an identifier is a global constant using `is_global_constant`. If true, it generates LLVM code to directly reference the global constant.

### Operator handling refinement:

* [`src/codegen/visitor_codegen.rs`](diffhunk://#diff-b12268da5b4824b54e95ff19307f2e0641c6b871ebb7f8dcffede68a5244ae93L378-R388): Renamed the `MINUS` operator token to `NEG` for clarity and updated the corresponding code generation logic for unary negation.